### PR TITLE
Add retry logic for server errors and rate limit API requests

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -230,6 +230,12 @@ async def fetch(
         try:
             async with ClientSession() as session:
                 async with session.get(url, headers=default_headers, params=params) as response:
+                    if response.status >= 500:
+                        logger.error("Failed to fetch %s: Status %s", url, response.status)
+                        if i < retries - 1:
+                            await asyncio.sleep(pause * (i + 1))
+                            continue
+                        raise Exception(f"Failed to fetch {url}: Status {response.status}")
                     if response.status != 200:
                         logger.error("Failed to fetch %s: Status %s", url, response.status)
                         raise Exception(f"Failed to fetch {url}: Status {response.status}")

--- a/src/vlrgg.py
+++ b/src/vlrgg.py
@@ -26,6 +26,9 @@ logger = logutil.init_logger(__name__)
 
 VLRGG_API_URL = "https://vlr.drndvs.fr"
 
+# Limite de requêtes concurrentes vers l'API (éviter les 502 sur le serveur self-hosted)
+_api_semaphore = asyncio.Semaphore(2)
+
 # Cache TTL en secondes par type d'endpoint (valeurs basses, API self-hosted)
 CACHE_TTL = {
     "live": 10,
@@ -87,7 +90,8 @@ async def vlrgg_request(
 
     url = f"{VLRGG_API_URL}/{endpoint}"
     try:
-        data: Dict[str, Any] = await fetch(url, params=params, return_type="json")  # type: ignore[assignment]
+        async with _api_semaphore:
+            data: Dict[str, Any] = await fetch(url, params=params, return_type="json")  # type: ignore[assignment]
         _cache[key] = (time.monotonic(), data)
         return data
     except Exception as e:


### PR DESCRIPTION
## Summary
This PR improves the reliability and stability of API requests by implementing retry logic for server errors and adding concurrency control to prevent overwhelming the self-hosted API server.

## Key Changes
- **Retry logic for 5xx errors**: Added handling for HTTP 500+ status codes in the `fetch()` function with exponential backoff retry mechanism. Server errors now trigger retries with increasing delays instead of immediately failing.
- **API request rate limiting**: Introduced an `asyncio.Semaphore` with a limit of 2 concurrent requests to the VLR.gg API to prevent 502 errors on the self-hosted server.
- **Improved error handling**: Server errors (5xx) are now distinguished from other HTTP errors, allowing for appropriate retry behavior while still failing fast on client errors (4xx).

## Implementation Details
- The semaphore wraps the `vlrgg_request()` API call to ensure no more than 2 concurrent requests are made at any time
- Retry attempts use exponential backoff: `pause * (i + 1)` where `i` is the attempt number
- The retry logic respects the configured `retries` parameter and only retries on 5xx errors

https://claude.ai/code/session_01Q9TjotVCmYLksXq4FpmxQd