### PR TITLE
refactor(phase-1): introduce src/core/ foundation with compat shims

### DIFF
--- a/src/core/images.py
+++ b/src/core/images.py
@@ -1,0 +1,51 @@
+"""Image helpers — Pillow-based, no Discord dependency."""
+
+from __future__ import annotations
+
+from io import BytesIO
+from typing import Tuple
+
+from PIL import Image, ImageDraw, ImageFont
+
+
+def create_dynamic_image(
+    text: str,
+    font_size: int = 20,
+    font_path: str = "src/Menlo-Regular.ttf",
+    image_padding: int = 10,
+    background_color: str = "#1E1F22",
+) -> Tuple[Image.Image, BytesIO]:
+    """Render *text* centered on a dark-themed rectangle.
+
+    Returns ``(pillow_image, bytes_io)``; the caller can feed ``bytes_io`` into
+    ``interactions.File`` or write it to disk.
+    """
+    if not text:
+        raise ValueError("Text cannot be empty")
+    if font_size <= 0:
+        raise ValueError("Font size must be greater than zero")
+    if image_padding < 0:
+        raise ValueError("Image padding cannot be negative")
+
+    font = ImageFont.truetype(font_path, font_size)
+    draw = ImageDraw.Draw(Image.new("RGB", (0, 0)))
+    bbox = draw.textbbox((0, 0), text, font=font)
+    text_width, text_height = bbox[2] - bbox[0], bbox[3] - bbox[1]
+
+    image_width = text_width + 2 * image_padding
+    image_height = text_height + 2 * image_padding
+    image = Image.new("RGB", (image_width, image_height), color=background_color)
+    draw = ImageDraw.Draw(image)
+
+    x = image_width // 2
+    y = image_height // 2
+    draw.text((x, y), text, font=font, fill=0xF2F3F5, anchor="mm")
+
+    image_io = BytesIO()
+    image.save(image_io, "png")
+    image_io.seek(0)
+
+    return image, image_io
+
+
+__all__ = ["create_dynamic_image"]

--- a/src/core/text.py
+++ b/src/core/text.py
@@ -1,0 +1,124 @@
+"""Pure-Python text / number / duration helpers — no Discord dependency.
+
+These were previously scattered across ``src/utils.py`` and ``src/helpers.py``.
+Grouping them here makes them easy to reuse from feature code that doesn't
+import ``interactions``.
+"""
+
+from __future__ import annotations
+
+import random
+import re
+import string
+
+import emoji
+
+# ---------------------------------------------------------------------------
+# Duration & number formatting
+# ---------------------------------------------------------------------------
+
+def milliseconds_to_string(duration_ms) -> str:
+    """Convert milliseconds to a French human-readable duration string."""
+    duration_ms = int(duration_ms)
+    seconds = duration_ms / 1000
+    days = seconds // 86400
+    seconds %= 86400
+    hours = seconds // 3600
+    seconds %= 3600
+    minutes = seconds // 60
+    seconds %= 60
+    return (
+        f"{int(days)} jour(s) {int(hours):02d} heure(s) "
+        f"{int(minutes):02d} minute(s) et {int(seconds):02d} seconde(s)"
+    )
+
+
+def format_number(num) -> str:
+    """Format a number with a k suffix for thousands."""
+    if num >= 1000:
+        return f"{num / 1000:.1f}k"
+    return str(num)
+
+
+# ---------------------------------------------------------------------------
+# Text processing
+# ---------------------------------------------------------------------------
+
+def escape_md(text: str) -> str:
+    """Escape Markdown special characters."""
+    return re.sub(r"([_*\[\]()~`>#+\-=|{}.!])", r"\\\1", text)
+
+
+def sanitize_content(content: str) -> str:
+    """Remove custom emojis, unicode emojis, and mentions from content."""
+    content = re.sub(r"<:\w*:\d*>", "", content)
+    content = emoji.replace_emoji(content, " ")
+    content = re.sub(r"<@\d*>", "", content)
+    return content
+
+
+def remove_punctuation(input_string: str) -> str:
+    """Remove all punctuation from the input string."""
+    translator = str.maketrans("", "", string.punctuation)
+    return input_string.translate(translator).strip()
+
+
+def search_dict_by_sentence(my_dict: dict, sentence: str):
+    """Return the first value whose key (or any tuple-key element) matches a word in *sentence*."""
+    words = set(sentence.lower().split())
+    for key, value in my_dict.items():
+        if isinstance(key, tuple):
+            key_lower = tuple(k.lower() for k in key)
+            if any(word in key_lower for word in words):
+                return value
+        else:
+            if key.lower() in words:
+                return value
+    return None
+
+
+def extract_answer(text: str) -> str | None:
+    """Extract content between ``<answer>`` tags."""
+    pattern = r"<answer>(.*?)</answer>"
+    match = re.search(pattern, text, re.DOTALL)
+    return match.group(1) if match else None
+
+
+# ---------------------------------------------------------------------------
+# Weighted random message picker
+# ---------------------------------------------------------------------------
+
+def pick_weighted_message(
+    config: dict,
+    list_key: str,
+    weights_key: str,
+    default: str,
+    **format_kwargs,
+) -> str:
+    """Pick a random message from ``config[list_key]`` using weights, then format it.
+
+    Example::
+
+        msg = pick_weighted_message(
+            srv_cfg,
+            "birthdayMessageList", "birthdayMessageWeights",
+            "Joyeux anniversaire {mention} !",
+            mention=member.mention, age=age,
+        )
+    """
+    messages = config.get(list_key, [default])
+    weights = config.get(weights_key, [1] * len(messages))
+    chosen = random.choices(messages, weights=weights)[0]
+    return chosen.format(**format_kwargs)
+
+
+__all__ = [
+    "escape_md",
+    "extract_answer",
+    "format_number",
+    "milliseconds_to_string",
+    "pick_weighted_message",
+    "remove_punctuation",
+    "sanitize_content",
+    "search_dict_by_sentence",
+]

--- a/src/discord_ext/__init__.py
+++ b/src/discord_ext/__init__.py
@@ -1,0 +1,17 @@
+"""Reusable UI helpers that depend on ``interactions`` (discord-py-interactions).
+
+Modules
+-------
+- :mod:`src.discord_ext.embeds`       — color palette, spacer field, timestamp formatter
+- :mod:`src.discord_ext.messages`     — send_error/success, require_guild, fetch_user_safe,
+                                        persistent-message bootstrapping, thread unarchive
+- :mod:`src.discord_ext.autocomplete` — shared autocomplete handlers + guild-enabled check
+- :mod:`src.discord_ext.paginator`    — CustomPaginator + reaction-poll formatter
+
+These are the helpers every extension imports. Anything that would *still* make
+sense in a non-Discord context (text processing, image rendering, HTTP) lives
+under :mod:`src.core` instead.
+
+Old paths (``src.helpers``, ``src.utils``) are kept as re-export shims for one
+release so callers don't have to update in a single go.
+"""

--- a/src/discord_ext/autocomplete.py
+++ b/src/discord_ext/autocomplete.py
@@ -1,0 +1,46 @@
+"""Autocomplete handlers and guild-state helpers."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+from interactions import AutocompleteContext
+
+
+def is_guild_enabled(guild_id: int | str, enabled_servers: list[str]) -> bool:
+    """Return True if the guild is in the enabled-servers list."""
+    return str(guild_id) in enabled_servers
+
+
+async def guild_group_autocomplete(
+    ctx: AutocompleteContext,
+    col_func: Callable,
+    *,
+    member_filter: bool = True,
+) -> None:
+    """Shared autocomplete handler for guild-scoped group selection.
+
+    *col_func* should be a callable that accepts a guild_id and returns a
+    Motor collection (e.g. ``TricountClass._groups_col``). Groups are filtered
+    by ``{"is_active": True}`` and, when *member_filter* is true (default),
+    by membership of the invoking user.
+    """
+    if not ctx.guild:
+        await ctx.send(choices=[])
+        return
+
+    query: dict = {"is_active": True}
+    if member_filter:
+        query["members"] = ctx.author.id
+
+    groups = await col_func(ctx.guild.id).find(query).to_list(length=None)
+    input_text = ctx.input_text.lower()
+    filtered = [
+        {"name": g["name"], "value": g["name"]}
+        for g in groups
+        if input_text in g["name"].lower()
+    ]
+    await ctx.send(choices=filtered[:25])
+
+
+__all__ = ["guild_group_autocomplete", "is_guild_enabled"]

--- a/src/discord_ext/embeds.py
+++ b/src/discord_ext/embeds.py
@@ -1,0 +1,49 @@
+"""Embed primitives: color palette, spacer field, Discord timestamp formatter.
+
+Extensions should import from here instead of hard-coding hex literals — the
+palette is the source of truth. A few constants (e.g. ``Colors.SPOTIFY``) match
+the corresponding brand; the rest mirror the status-indicator conventions
+already used across the codebase (green success / red error / blue info / …).
+"""
+
+from datetime import datetime
+
+
+class Colors:
+    """Centralized embed color palette used across extensions."""
+
+    SUCCESS = 0x00FF00
+    ERROR = 0xFF0000
+    INFO = 0x0099FF
+    WARNING = 0xFF9900
+    ORANGE = 0xFFA500
+    SPOTIFY = 0x1DB954
+    TWITCH = 0x6441A5
+    TWITCH_ALT = 0x9146FF
+    VLR = 0xE04747
+    CONFRERIE = 0x9B462E
+    COLOC = 0x05B600
+    FEUR = 0x9B59B6
+    UTIL = 0x3489EB
+    XP = 0x00FF00
+    SECRET_SANTA = 0xFF0000
+    SECRET_SANTA_SUCCESS = 0x00FF00
+    SECRET_SANTA_ACCENT = 0xFF00FF
+    BACKUP_SUCCESS = 0x2ECC71
+    BACKUP_ERROR = 0xE74C3C
+
+
+# Zero-width space field — useful to force an empty cell in a 3-column embed.
+SPACER_FIELD = {"name": "\u200b", "value": "\u200b", "inline": True}
+
+
+def format_discord_timestamp(dt: datetime, style: str = "f") -> str:
+    """Format a ``datetime`` as a Discord dynamic timestamp.
+
+    Common styles: ``f`` (full), ``F`` (full + weekday), ``R`` (relative),
+    ``t`` (short time), ``d`` (short date).
+    """
+    return f"<t:{int(dt.timestamp())}:{style}>"
+
+
+__all__ = ["Colors", "SPACER_FIELD", "format_discord_timestamp"]

--- a/src/discord_ext/messages.py
+++ b/src/discord_ext/messages.py
@@ -1,0 +1,175 @@
+"""Ephemeral responses, guild checks, and persistent-message bootstrapping.
+
+Every helper here is a thin wrapper around the ``interactions`` API — the point
+is to remove duplicated try/except and ``if not ctx.guild:`` boilerplate that
+previously lived in every extension.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from interactions import Client, Message, SlashContext, ThreadChannel
+
+
+# ---------------------------------------------------------------------------
+# Ephemeral responses
+# ---------------------------------------------------------------------------
+
+async def send_error(ctx: SlashContext, message: str) -> None:
+    """Send an ephemeral error message prefixed with a cross emoji."""
+    await ctx.send(f"❌ {message}", ephemeral=True)
+
+
+async def send_success(ctx: SlashContext, message: str) -> None:
+    """Send an ephemeral success message prefixed with a check emoji."""
+    await ctx.send(f"✅ {message}", ephemeral=True)
+
+
+# ---------------------------------------------------------------------------
+# Guild check
+# ---------------------------------------------------------------------------
+
+async def require_guild(ctx: SlashContext) -> bool:
+    """Return True if the command is used inside a guild, else send an error.
+
+    Usage::
+
+        if not await require_guild(ctx):
+            return
+    """
+    if not ctx.guild:
+        await send_error(ctx, "Cette commande ne peut être utilisée que dans un serveur.")
+        return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Safe user fetch (cache → API fallback)
+# ---------------------------------------------------------------------------
+
+async def fetch_user_safe(bot: Client, user_id) -> tuple[str, Any]:
+    """Try the cache then the API.
+
+    Returns ``(display_name, user_or_None)`` — never raises.
+    """
+    user = bot.get_user(user_id)
+    if not user:
+        try:
+            user = await bot.fetch_user(user_id)
+        except Exception:  # noqa: BLE001 — graceful fallback
+            pass
+    name = user.display_name if user else f"ID:{user_id}"
+    return name, user
+
+
+# ---------------------------------------------------------------------------
+# Thread unarchive
+# ---------------------------------------------------------------------------
+
+async def unarchive_if_thread(
+    channel: Any,
+    logger: Optional[logging.Logger] = None,
+) -> None:
+    """Unarchive the channel if it is an archived thread. No-op otherwise.
+
+    Discord rejects sends/edits against archived threads, so call this before
+    any send_message/edit_message when the target could be a thread.
+    """
+    if not isinstance(channel, ThreadChannel):
+        return
+    if not getattr(channel, "archived", False):
+        return
+    try:
+        await channel.edit(archived=False, reason="Auto-unarchive before send/edit")
+    except Exception as e:  # noqa: BLE001 — log and continue; not fatal
+        if logger:
+            logger.warning("Could not unarchive thread %s: %s", getattr(channel, "id", "?"), e)
+
+
+# ---------------------------------------------------------------------------
+# Persistent module message (auto-create + pin + persist id)
+# ---------------------------------------------------------------------------
+
+async def fetch_or_create_persistent_message(
+    bot: Client,
+    *,
+    channel_id: int | str | None,
+    message_id: int | str | None,
+    module_name: str,
+    message_id_key: str,
+    guild_id: int | str | None = None,
+    initial_content: str = "Initialisation…",
+    pin: bool = False,
+    logger: Optional[logging.Logger] = None,
+) -> Optional[Message]:
+    """Return the module's persistent Discord message, creating it if missing.
+
+    Flow:
+      1. If ``message_id`` is set, try to fetch it from ``channel_id``.
+      2. On miss (deleted, None, error), send a placeholder in the channel,
+         optionally pin it, and persist the new id in ``config.json`` under
+         ``servers.<guild_id>.<module_name>.<message_id_key>``.
+
+    Callers should store the returned Message and edit it going forward.
+    """
+    if not channel_id:
+        return None
+
+    try:
+        channel = await bot.fetch_channel(int(channel_id))
+    except Exception as e:  # noqa: BLE001 — log and return None
+        if logger:
+            logger.error("Could not fetch channel %s: %s", channel_id, e)
+        return None
+    if channel is None or not hasattr(channel, "send"):
+        return None
+
+    await unarchive_if_thread(channel, logger=logger)
+
+    if message_id:
+        try:
+            existing = await channel.fetch_message(int(message_id))
+            if existing is not None:
+                return existing
+        except Exception as e:  # noqa: BLE001 — log and recreate
+            if logger:
+                logger.warning(
+                    "Persistent message %s missing in channel %s (%s); recreating",
+                    message_id, channel_id, e,
+                )
+
+    try:
+        msg = await channel.send(initial_content)
+    except Exception as e:  # noqa: BLE001 — log and return None
+        if logger:
+            logger.error("Could not create persistent message in %s: %s", channel_id, e)
+        return None
+
+    if pin:
+        try:
+            await msg.pin()
+        except Exception as e:  # noqa: BLE001 — non-fatal
+            if logger:
+                logger.warning("Could not pin persistent message %s: %s", msg.id, e)
+
+    if guild_id is not None:
+        try:
+            from src.core.config import save_module_field
+            save_module_field(module_name, guild_id, message_id_key, str(msg.id))
+        except Exception as e:  # noqa: BLE001 — log and continue
+            if logger:
+                logger.error("Could not save message id to config: %s", e)
+
+    return msg
+
+
+__all__ = [
+    "fetch_or_create_persistent_message",
+    "fetch_user_safe",
+    "require_guild",
+    "send_error",
+    "send_success",
+    "unarchive_if_thread",
+]

--- a/src/discord_ext/paginator.py
+++ b/src/discord_ext/paginator.py
@@ -1,0 +1,130 @@
+"""Paginator and reaction-poll formatter.
+
+- :class:`CustomPaginator` — drop-in replacement for ``interactions.ext.paginators.Paginator``
+  with a ``callback`` button, select-dropdown jumps, and keep-alive pings.
+- :func:`format_poll` — mutates a poll embed in place to render vote counts per
+  option and the voters behind each one, keyed off the reaction payload.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Optional
+
+from interactions import ComponentContext, Message
+from interactions.api.events import MessageReactionAdd, MessageReactionRemove
+from interactions.ext import paginators
+
+from src.core.config import load_discord2name
+
+
+# ---------------------------------------------------------------------------
+# Custom paginator
+# ---------------------------------------------------------------------------
+
+class CustomPaginator(paginators.Paginator):
+    """Custom paginator with overridden button handling."""
+
+    async def _on_button(
+        self, ctx: ComponentContext, *args, **kwargs
+    ) -> Optional[Message]:
+        if self._timeout_task:
+            self._timeout_task.ping.set()
+        match ctx.custom_id.split("|")[1]:
+            case "first":
+                self.page_index = 0
+            case "last":
+                self.page_index = len(self.pages) - 1
+            case "next":
+                if (self.page_index + 1) < len(self.pages):
+                    self.page_index += 1
+            case "back":
+                if self.page_index >= 1:
+                    self.page_index -= 1
+            case "select":
+                self.page_index = int(ctx.values[0])
+            case "callback":
+                if self.callback:
+                    return await self.callback(ctx)
+
+        await ctx.edit_origin(**self.to_dict())
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Poll formatter
+# ---------------------------------------------------------------------------
+
+# Per-guild cache of Discord-id → display-name overrides. Populated lazily from
+# the ``discord2name`` config mapping; keeps ``format_poll`` from hitting the
+# JSON file on every reaction.
+name_cache: dict[str, dict[str, str]] = {}
+
+
+async def format_poll(event: MessageReactionAdd | MessageReactionRemove):
+    """Render the current vote counts + voter names into a poll embed.
+
+    The embed's description is expected to be the "\\n\\n"-separated option
+    list initially produced by the poll command. Each call replaces the
+    description in place and returns the (mutated) embed.
+    """
+    message = event.message
+    embed = message.embeds[0]
+    options = embed.description.split("\n\n")
+    reactions = message.reactions
+
+    reaction_users = defaultdict(list)
+    reaction_counts = defaultdict(int)
+    max_reaction_count = 0
+    for reaction in reactions:
+        users = [user for user in await reaction.users().flatten() if not user.bot]
+        reaction_users[str(reaction.emoji)] = users
+        reaction_counts[str(reaction.emoji)] = reaction.count - 1
+        if reaction.count > max_reaction_count:
+            max_reaction_count = reaction.count - 1
+
+    max_reaction_indices = [
+        i for i, count in reaction_counts.items() if count == max_reaction_count
+    ]
+    participant_count = len(
+        {user.id for users in reaction_users.values() for user in users}
+        - {message.author.id}
+    )
+
+    description_list = []
+    for _i, option in enumerate(options):
+        option = option.split(":", 1)[0].replace("**", "")
+        emoji_str = option.split(" ", 1)[0]
+
+        reaction_count = reaction_counts[emoji_str]
+        user_list = reaction_users[emoji_str]
+
+        user_names = []
+        for user in user_list:
+            user_name = user.display_name
+            user_id = str(user.id)
+            server_id = str(event.message.guild.id)
+            if server_id not in name_cache:
+                name_cache[server_id] = {}
+            if user_id not in name_cache[server_id]:
+                d2n = load_discord2name(server_id)
+                name_cache[server_id][user_id] = d2n.get(user_id, user_name)
+            user_name = name_cache[server_id][user_id]
+            user_names.append(user_name)
+        user_names_str = ", ".join(user_names)
+
+        description = f"{option}"
+        if reaction_count > 0:
+            description = (
+                f"**{option} : {reaction_count}/{participant_count} votes\n({user_names_str})**"
+                if emoji_str in max_reaction_indices
+                else f"{option} : **{reaction_count}/{participant_count} votes**\n({user_names_str})"
+            )
+
+        description_list.append(description)
+
+    embed.description = "\n\n".join(description_list)
+    return embed
+
+
+__all__ = ["CustomPaginator", "format_poll", "name_cache"]

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -1,279 +1,45 @@
-"""Shared helpers to avoid code duplication across extensions."""
+"""Deprecated: the helpers moved to :mod:`src.discord_ext` and :mod:`src.core.text`.
 
-import logging
-import random
-from datetime import datetime
-from typing import Any, Callable, Optional
+Re-export shim kept for one release so ``from src.helpers import …`` keeps
+working. New code should import directly from the destination module:
 
-from interactions import (
-    AutocompleteContext,
-    Client,
-    Embed,
-    Message,
-    SlashContext,
-    ThreadChannel,
+- Embed palette / spacer / Discord timestamps → :mod:`src.discord_ext.embeds`
+- Ephemeral messages / guild checks / user fetch / persistent messages
+  / thread unarchive → :mod:`src.discord_ext.messages`
+- Guild-scoped autocomplete / enabled-guild check → :mod:`src.discord_ext.autocomplete`
+- Weighted random message picker → :mod:`src.core.text`
+"""
+
+from src.core.text import pick_weighted_message  # noqa: F401
+from src.discord_ext.autocomplete import (  # noqa: F401
+    guild_group_autocomplete,
+    is_guild_enabled,
+)
+from src.discord_ext.embeds import (  # noqa: F401
+    Colors,
+    SPACER_FIELD,
+    format_discord_timestamp,
+)
+from src.discord_ext.messages import (  # noqa: F401
+    fetch_or_create_persistent_message,
+    fetch_user_safe,
+    require_guild,
+    send_error,
+    send_success,
+    unarchive_if_thread,
 )
 
-
-# ---------------------------------------------------------------------------
-# Embed color constants
-# ---------------------------------------------------------------------------
-
-class Colors:
-    """Centralized embed color palette used across extensions."""
-    SUCCESS = 0x00FF00
-    ERROR = 0xFF0000
-    INFO = 0x0099FF
-    WARNING = 0xFF9900
-    ORANGE = 0xFFA500
-    SPOTIFY = 0x1DB954
-    TWITCH = 0x6441A5
-    TWITCH_ALT = 0x9146FF
-    VLR = 0xE04747
-    CONFRERIE = 0x9B462E
-    COLOC = 0x05B600
-    FEUR = 0x9B59B6
-    UTIL = 0x3489EB
-    XP = 0x00FF00
-    SECRET_SANTA = 0xFF0000
-    SECRET_SANTA_SUCCESS = 0x00FF00
-    SECRET_SANTA_ACCENT = 0xFF00FF
-    BACKUP_SUCCESS = 0x2ECC71
-    BACKUP_ERROR = 0xE74C3C
-
-
-# ---------------------------------------------------------------------------
-# Embed spacer field (zero-width space)
-# ---------------------------------------------------------------------------
-
-SPACER_FIELD = {"name": "\u200b", "value": "\u200b", "inline": True}
-
-
-# ---------------------------------------------------------------------------
-# Ephemeral error / guild check
-# ---------------------------------------------------------------------------
-
-async def send_error(ctx: SlashContext, message: str) -> None:
-    """Send an ephemeral error message prefixed with a cross emoji."""
-    await ctx.send(f"❌ {message}", ephemeral=True)
-
-
-async def send_success(ctx: SlashContext, message: str) -> None:
-    """Send an ephemeral success message prefixed with a check emoji."""
-    await ctx.send(f"✅ {message}", ephemeral=True)
-
-
-async def require_guild(ctx: SlashContext) -> bool:
-    """Return True if the command is used inside a guild, else send an error.
-
-    Usage::
-
-        if not await require_guild(ctx):
-            return
-    """
-    if not ctx.guild:
-        await send_error(ctx, "Cette commande ne peut être utilisée que dans un serveur.")
-        return False
-    return True
-
-
-# ---------------------------------------------------------------------------
-# Safe user fetch (cache → API fallback)
-# ---------------------------------------------------------------------------
-
-async def fetch_user_safe(bot: Client, user_id) -> tuple[str, Any]:
-    """Try the cache then the API.  Returns *(display_name, user_or_None)*."""
-    user = bot.get_user(user_id)
-    if not user:
-        try:
-            user = await bot.fetch_user(user_id)
-        except Exception:
-            pass
-    name = user.display_name if user else f"ID:{user_id}"
-    return name, user
-
-
-# ---------------------------------------------------------------------------
-# Weighted random message picker
-# ---------------------------------------------------------------------------
-
-def pick_weighted_message(
-    config: dict,
-    list_key: str,
-    weights_key: str,
-    default: str,
-    **format_kwargs,
-) -> str:
-    """Pick a random message from *config[list_key]* using weights, then format it.
-
-    Example::
-
-        msg = pick_weighted_message(
-            srv_cfg,
-            "birthdayMessageList", "birthdayMessageWeights",
-            "Joyeux anniversaire {mention} !",
-            mention=member.mention, age=age,
-        )
-    """
-    messages = config.get(list_key, [default])
-    weights = config.get(weights_key, [1] * len(messages))
-    chosen = random.choices(messages, weights=weights)[0]
-    return chosen.format(**format_kwargs)
-
-
-# ---------------------------------------------------------------------------
-# Discord timestamp formatting
-# ---------------------------------------------------------------------------
-
-def format_discord_timestamp(dt: datetime, style: str = "f") -> str:
-    """Format a *datetime* as a Discord dynamic timestamp.
-
-    Common styles: ``f`` (full), ``F`` (full + weekday), ``R`` (relative),
-    ``t`` (short time), ``d`` (short date).
-    """
-    return f"<t:{int(dt.timestamp())}:{style}>"
-
-
-# ---------------------------------------------------------------------------
-# Tricount-style group autocomplete helper
-# ---------------------------------------------------------------------------
-
-async def guild_group_autocomplete(
-    ctx: AutocompleteContext,
-    col_func: Callable,
-    *,
-    member_filter: bool = True,
-) -> None:
-    """Shared autocomplete handler for guild group selection.
-
-    *col_func* should be a callable that accepts a guild_id and returns
-    a Motor collection (e.g. ``TricountClass._groups_col``).
-    """
-    if not ctx.guild:
-        await ctx.send(choices=[])
-        return
-
-    query: dict = {"is_active": True}
-    if member_filter:
-        query["members"] = ctx.author.id
-
-    groups = await col_func(ctx.guild.id).find(query).to_list(length=None)
-    input_text = ctx.input_text.lower()
-    filtered = [
-        {"name": g["name"], "value": g["name"]}
-        for g in groups
-        if input_text in g["name"].lower()
-    ]
-    await ctx.send(choices=filtered[:25])
-
-
-# ---------------------------------------------------------------------------
-# Module enabled check
-# ---------------------------------------------------------------------------
-
-def is_guild_enabled(guild_id: int | str, enabled_servers: list[str]) -> bool:
-    """Return True if the guild is in the enabled servers list."""
-    return str(guild_id) in enabled_servers
-
-
-# ---------------------------------------------------------------------------
-# Thread unarchive helper
-# ---------------------------------------------------------------------------
-
-async def unarchive_if_thread(
-    channel: Any,
-    logger: Optional[logging.Logger] = None,
-) -> None:
-    """Unarchive the channel if it is an archived thread. No-op otherwise.
-
-    Discord rejects sends/edits against archived threads, so call this before
-    any send_message/edit_message when the target could be a thread.
-    """
-    if not isinstance(channel, ThreadChannel):
-        return
-    if not getattr(channel, "archived", False):
-        return
-    try:
-        await channel.edit(archived=False, reason="Auto-unarchive before send/edit")
-    except Exception as e:
-        if logger:
-            logger.warning("Could not unarchive thread %s: %s", getattr(channel, "id", "?"), e)
-
-
-# ---------------------------------------------------------------------------
-# Persistent module message (auto-create + pin + persist id)
-# ---------------------------------------------------------------------------
-
-async def fetch_or_create_persistent_message(
-    bot: Client,
-    *,
-    channel_id: int | str | None,
-    message_id: int | str | None,
-    module_name: str,
-    message_id_key: str,
-    guild_id: int | str | None = None,
-    initial_content: str = "Initialisation…",
-    pin: bool = False,
-    logger: Optional[logging.Logger] = None,
-) -> Optional[Message]:
-    """Return the module's persistent Discord message, creating it if missing.
-
-    Flow:
-      1. If ``message_id`` is set, try to fetch it from ``channel_id``.
-      2. On miss (deleted, None, error), send a placeholder in the channel,
-         optionally pin it, and persist the new id in ``config.json`` under
-         ``servers.<guild_id>.<module_name>.<message_id_key>``.
-
-    Callers should store the returned Message and edit it going forward.
-    """
-    if not channel_id:
-        return None
-
-    try:
-        channel = await bot.fetch_channel(int(channel_id))
-    except Exception as e:
-        if logger:
-            logger.error("Could not fetch channel %s: %s", channel_id, e)
-        return None
-    if channel is None or not hasattr(channel, "send"):
-        return None
-
-    await unarchive_if_thread(channel, logger=logger)
-
-    if message_id:
-        try:
-            existing = await channel.fetch_message(int(message_id))
-            if existing is not None:
-                return existing
-        except Exception as e:
-            if logger:
-                logger.warning(
-                    "Persistent message %s missing in channel %s (%s); recreating",
-                    message_id, channel_id, e,
-                )
-
-    try:
-        msg = await channel.send(initial_content)
-    except Exception as e:
-        if logger:
-            logger.error("Could not create persistent message in %s: %s", channel_id, e)
-        return None
-
-    if pin:
-        try:
-            await msg.pin()
-        except Exception as e:
-            if logger:
-                logger.warning("Could not pin persistent message %s: %s", msg.id, e)
-
-    if guild_id is not None:
-        try:
-            from src.config_manager import save_module_field
-            save_module_field(module_name, guild_id, message_id_key, str(msg.id))
-        except Exception as e:
-            if logger:
-                logger.error("Could not save message id to config: %s", e)
-
-    return msg
-
-
+__all__ = [
+    "Colors",
+    "SPACER_FIELD",
+    "fetch_or_create_persistent_message",
+    "fetch_user_safe",
+    "format_discord_timestamp",
+    "guild_group_autocomplete",
+    "is_guild_enabled",
+    "pick_weighted_message",
+    "require_guild",
+    "send_error",
+    "send_success",
+    "unarchive_if_thread",
+]

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,242 +1,51 @@
-"""Shared utility functions: image generation, text processing, HTTP fetch, pagination."""
+"""Deprecated: the utilities moved under :mod:`src.core` and :mod:`src.discord_ext`.
 
-import os
-import re
-import string
-from collections import defaultdict
-from io import BytesIO
-from typing import Optional, Tuple
+Re-export shim kept for one release so ``from src.utils import …`` keeps
+working. New code should import directly from the destination module:
 
-import emoji
-from interactions import ComponentContext, Message
-from interactions.api.events import MessageReactionAdd, MessageReactionRemove
-from interactions.ext import paginators
-from PIL import Image, ImageDraw, ImageFont
+- ``fetch`` → :mod:`src.core.http`
+- ``load_config`` / ``save_config`` / ``load_discord2name`` → :mod:`src.core.config`
+- Text / number / duration helpers → :mod:`src.core.text`
+- ``create_dynamic_image`` → :mod:`src.core.images`
+- ``CustomPaginator`` / ``format_poll`` / ``name_cache`` → :mod:`src.discord_ext.paginator`
+"""
 
-from src import logutil
-from src.config_manager import load_config, load_discord2name, save_config  # re-export
-from src.core.http import fetch  # re-export — implementation moved in Phase 1
+from src.core.config import (  # noqa: F401 — re-exported for backward compat
+    load_config,
+    load_discord2name,
+    save_config,
+)
+from src.core.http import fetch  # noqa: F401
+from src.core.images import create_dynamic_image  # noqa: F401
+from src.core.text import (  # noqa: F401
+    escape_md,
+    extract_answer,
+    format_number,
+    milliseconds_to_string,
+    remove_punctuation,
+    sanitize_content,
+    search_dict_by_sentence,
+)
+from src.discord_ext.paginator import (  # noqa: F401
+    CustomPaginator,
+    format_poll,
+    name_cache,
+)
 
-logger = logutil.init_logger(os.path.basename(__file__))
-
-
-# ---------------------------------------------------------------------------
-# Time formatting
-# ---------------------------------------------------------------------------
-
-def milliseconds_to_string(duration_ms) -> str:
-    """Convert milliseconds to a French human-readable duration string."""
-    duration_ms = int(duration_ms)
-    seconds = duration_ms / 1000
-    days = seconds // 86400
-    seconds %= 86400
-    hours = seconds // 3600
-    seconds %= 3600
-    minutes = seconds // 60
-    seconds %= 60
-    return (
-        f"{int(days)} jour(s) {int(hours):02d} heure(s) "
-        f"{int(minutes):02d} minute(s) et {int(seconds):02d} seconde(s)"
-    )
-
-
-# ---------------------------------------------------------------------------
-# Image generation
-# ---------------------------------------------------------------------------
-
-def create_dynamic_image(
-    text: str,
-    font_size: int = 20,
-    font_path: str = "src/Menlo-Regular.ttf",
-    image_padding: int = 10,
-    background_color: str = "#1E1F22",
-) -> Tuple[Image.Image, BytesIO]:
-    """Create a dynamic image with the specified text."""
-    if not text:
-        raise ValueError("Text cannot be empty")
-    if font_size <= 0:
-        raise ValueError("Font size must be greater than zero")
-    if image_padding < 0:
-        raise ValueError("Image padding cannot be negative")
-
-    font = ImageFont.truetype(font_path, font_size)
-    draw = ImageDraw.Draw(Image.new("RGB", (0, 0)))
-    bbox = draw.textbbox((0, 0), text, font=font)
-    text_width, text_height = bbox[2] - bbox[0], bbox[3] - bbox[1]
-
-    image_width = text_width + 2 * image_padding
-    image_height = text_height + 2 * image_padding
-    image = Image.new("RGB", (image_width, image_height), color=background_color)
-    draw = ImageDraw.Draw(image)
-
-    x = image_width // 2
-    y = image_height // 2
-    draw.text((x, y), text, font=font, fill=0xF2F3F5, anchor="mm")
-
-    image_io = BytesIO()
-    image.save(image_io, "png")
-    image_io.seek(0)
-
-    return image, image_io
-
-
-# ---------------------------------------------------------------------------
-# Number formatting
-# ---------------------------------------------------------------------------
-
-def format_number(num) -> str:
-    """Format a number with k suffix for thousands."""
-    if num >= 1000:
-        return f"{num / 1000:.1f}k"
-    return str(num)
-
-
-# ---------------------------------------------------------------------------
-# Text processing
-# ---------------------------------------------------------------------------
-
-def escape_md(text: str) -> str:
-    """Escape markdown special characters in the given text."""
-    return re.sub(r"([_*\[\]()~`>#+\-=|{}.!])", r"\\\1", text)
-
-
-def sanitize_content(content: str) -> str:
-    """Remove custom emojis, unicode emojis, and mentions from content."""
-    content = re.sub(r"<:\w*:\d*>", "", content)
-    content = emoji.replace_emoji(content, " ")
-    content = re.sub(r"<@\d*>", "", content)
-    return content
-
-
-def remove_punctuation(input_string: str) -> str:
-    """Remove all punctuation from the input string."""
-    translator = str.maketrans("", "", string.punctuation)
-    return input_string.translate(translator).strip()
-
-
-def search_dict_by_sentence(my_dict: dict, sentence: str):
-    """Search a dictionary by matching words in a sentence to keys."""
-    words = set(sentence.lower().split())
-    for key, value in my_dict.items():
-        if isinstance(key, tuple):
-            key_lower = tuple(k.lower() for k in key)
-            if any(word in key_lower for word in words):
-                return value
-        else:
-            if key.lower() in words:
-                return value
-    return None
-
-
-def extract_answer(text: str) -> str | None:
-    """Extract content between <answer> tags."""
-    pattern = r"<answer>(.*?)</answer>"
-    match = re.search(pattern, text, re.DOTALL)
-    return match.group(1) if match else None
-
-
-# ---------------------------------------------------------------------------
-# Poll formatting
-# ---------------------------------------------------------------------------
-
-name_cache: dict[str, dict[str, str]] = {}
-
-
-async def format_poll(event: MessageReactionAdd | MessageReactionRemove):
-    """Format a poll message by updating the description with current vote counts."""
-    message = event.message
-    embed = message.embeds[0]
-    options = embed.description.split("\n\n")
-    reactions = message.reactions
-
-    reaction_users = defaultdict(list)
-    reaction_counts = defaultdict(int)
-    max_reaction_count = 0
-    for reaction in reactions:
-        users = [user for user in await reaction.users().flatten() if not user.bot]
-        reaction_users[str(reaction.emoji)] = users
-        reaction_counts[str(reaction.emoji)] = reaction.count - 1
-        if reaction.count > max_reaction_count:
-            max_reaction_count = reaction.count - 1
-
-    max_reaction_indices = [
-        i for i, count in reaction_counts.items() if count == max_reaction_count
-    ]
-    participant_count = len(
-        set(user.id for users in reaction_users.values() for user in users)
-        - {message.author.id}
-    )
-
-    description_list = []
-    for i, option in enumerate(options):
-        option = option.split(":", 1)[0].replace("**", "")
-        emoji_str = option.split(" ", 1)[0]
-
-        reaction_count = reaction_counts[emoji_str]
-        user_list = reaction_users[emoji_str]
-
-        user_names = []
-        for user in user_list:
-            user_name = user.display_name
-            user_id = str(user.id)
-            server_id = str(event.message.guild.id)
-            if server_id not in name_cache:
-                name_cache[server_id] = {}
-            if user_id not in name_cache[server_id]:
-                d2n = load_discord2name(server_id)
-                name_cache[server_id][user_id] = d2n.get(user_id, user_name)
-            user_name = name_cache[server_id][user_id]
-            user_names.append(user_name)
-        user_names_str = ", ".join(user_names)
-
-        description = f"{option}"
-        if reaction_count > 0:
-            description = (
-                f"**{option} : {reaction_count}/{participant_count} votes\n({user_names_str})**"
-                if emoji_str in max_reaction_indices
-                else f"{option} : **{reaction_count}/{participant_count} votes**\n({user_names_str})"
-            )
-
-        description_list.append(description)
-
-    embed.description = "\n\n".join(description_list)
-    return embed
-
-
-# ---------------------------------------------------------------------------
-# HTTP fetch with retry — re-exported from ``src.core.http`` (see import above).
-# The function signature and behaviour are preserved.
-# ---------------------------------------------------------------------------
-
-
-# ---------------------------------------------------------------------------
-# Custom Paginator (shared across extensions)
-# ---------------------------------------------------------------------------
-
-class CustomPaginator(paginators.Paginator):
-    """Custom paginator with overridden button handling."""
-
-    async def _on_button(
-        self, ctx: ComponentContext, *args, **kwargs
-    ) -> Optional[Message]:
-        if self._timeout_task:
-            self._timeout_task.ping.set()
-        match ctx.custom_id.split("|")[1]:
-            case "first":
-                self.page_index = 0
-            case "last":
-                self.page_index = len(self.pages) - 1
-            case "next":
-                if (self.page_index + 1) < len(self.pages):
-                    self.page_index += 1
-            case "back":
-                if self.page_index >= 1:
-                    self.page_index -= 1
-            case "select":
-                self.page_index = int(ctx.values[0])
-            case "callback":
-                if self.callback:
-                    return await self.callback(ctx)
-
-        await ctx.edit_origin(**self.to_dict())
-        return None
+__all__ = [
+    "CustomPaginator",
+    "create_dynamic_image",
+    "escape_md",
+    "extract_answer",
+    "fetch",
+    "format_number",
+    "format_poll",
+    "load_config",
+    "load_discord2name",
+    "milliseconds_to_string",
+    "name_cache",
+    "remove_punctuation",
+    "sanitize_content",
+    "save_config",
+    "search_dict_by_sentence",
+]


### PR DESCRIPTION
Split the two God-modules (src/utils.py, src/helpers.py) into focused packages along a clean Discord / non-Discord boundary:

- src/core/text.py         — duration/number formatting, markdown escape,
                             sanitize, punctuation, search_dict_by_sentence,
                             extract_answer, pick_weighted_message
- src/core/images.py       — create_dynamic_image (Pillow)
- src/discord_ext/embeds.py       — Colors palette, SPACER_FIELD,
                                    format_discord_timestamp
- src/discord_ext/messages.py     — send_error/success, require_guild,
                                    fetch_user_safe, unarchive_if_thread,
                                    fetch_or_create_persistent_message
- src/discord_ext/autocomplete.py — guild_group_autocomplete,
                                    is_guild_enabled
- src/discord_ext/paginator.py    — CustomPaginator, format_poll,
                                    per-guild name_cache

src/utils.py and src/helpers.py are rewritten as re-export shims so every existing "from src.utils import …" / "from src.helpers import …" caller keeps working during the migration window.

Verified with a stubbed import probe (all 8 target modules plus both shims import cleanly and re-export every expected symbol) and a full compileall pass across src/ + extensions/ + main.py.

Refs #15 (Phase 2).