### PR TITLE
refactor(phase-5): replace webui/schemas.py with per-module Pydantic configs

### DIFF
--- a/extensions/colocext.py
+++ b/extensions/colocext.py
@@ -67,6 +67,21 @@ from src.coloc.utils import (
 )
 from src.config_manager import load_config
 from src.helpers import fetch_user_safe, send_error
+from src.webui.schemas import SchemaBase, enabled_field, register_module, ui
+
+
+@register_module("moduleColoc")
+class ColocConfig(SchemaBase):
+    __label__ = "Colocation"
+    __description__ = "Gestion de la colocation et notifications Zunivers."
+    __icon__ = "🏠"
+    __category__ = "Communauté"
+
+    enabled: bool = enabled_field()
+    colocZuniversChannelId: str | None = ui(
+        "Salon Zunivers", "channel", description="Salon pour les notifications Zunivers."
+    )
+
 
 logger = logutil.init_logger(os.path.basename(__file__))
 

--- a/extensions/compareai.py
+++ b/extensions/compareai.py
@@ -38,6 +38,18 @@ from src import logutil
 from src.config_manager import load_config
 from src.helpers import fetch_user_safe, send_error, send_success
 from src.utils import search_dict_by_sentence
+from src.webui.schemas import SchemaBase, enabled_field, register_module
+
+
+@register_module("moduleIA")
+class IAConfig(SchemaBase):
+    __label__ = "Intelligence Artificielle"
+    __description__ = "Comparaison de modèles IA via OpenRouter."
+    __icon__ = "🤖"
+    __category__ = "Outils"
+
+    enabled: bool = enabled_field()
+
 
 # =============================================================================
 # Configuration and Constants

--- a/extensions/confrerie/_common.py
+++ b/extensions/confrerie/_common.py
@@ -6,8 +6,64 @@ from interactions import SlashCommandChoice
 
 from src import logutil
 from src.config_manager import load_config
+from src.webui.schemas import (
+    SchemaBase,
+    enabled_field,
+    hidden_message_id,
+    register_module,
+    ui,
+)
 
 logger = logutil.init_logger(os.path.basename(__file__))
+
+
+@register_module("moduleConfrerie")
+class ConfrerieConfig(SchemaBase):
+    __label__ = "Confrérie"
+    __description__ = "Intégration Notion pour la Confrérie des Traducteurs."
+    __icon__ = "📚"
+    __category__ = "Outils"
+
+    enabled: bool = enabled_field()
+    confrerieNotionDbOeuvresId: str = ui(
+        "Notion DB Œuvres",
+        "string",
+        required=True,
+        description="ID de la base de données Notion pour les œuvres.",
+    )
+    confrerieNotionDbIdEditorsId: str | None = ui(
+        "Notion DB Éditeurs",
+        "string",
+        description="ID de la base de données Notion pour les éditeurs.",
+    )
+    confrerieRecapChannelId: str | None = ui(
+        "Salon récap",
+        "channel",
+        description="Salon pour le message de récapitulatif (créé automatiquement).",
+    )
+    confrerieRecapPinMessage: bool = ui(
+        "Épingler le message récap",
+        "boolean",
+        default=False,
+        description="Épingler automatiquement le message de récap.",
+    )
+    confrerieRecapMessageId: str | None = hidden_message_id(
+        "Message récap", "confrerieRecapChannelId"
+    )
+    confrerieDefiChannelId: str | None = ui(
+        "Salon défis", "channel", description="Salon pour les défis de traduction."
+    )
+    confrerieNewTextChannelId: str | None = ui(
+        "Salon nouveaux textes",
+        "channel",
+        description="Salon pour les notifications de nouveaux textes.",
+    )
+    confrerieOwnerId: str | None = ui(
+        "ID propriétaire",
+        "string",
+        description="ID Discord du propriétaire de la confrérie.",
+    )
+
 
 config, module_config, enabled_servers = load_config("moduleConfrerie")
 module_config = module_config[enabled_servers[0]] if enabled_servers else {}

--- a/extensions/embedmanager.py
+++ b/extensions/embedmanager.py
@@ -13,6 +13,7 @@ Features:
 """
 
 import os
+from typing import Any
 
 from interactions import (
     Client,
@@ -21,6 +22,43 @@ from interactions import (
 )
 
 from src import logutil
+from src.webui.schemas import (
+    SchemaBase,
+    enabled_field,
+    hidden_message_id,
+    register_module,
+    ui,
+)
+
+
+@register_module("moduleEmbedManager")
+class EmbedManagerConfig(SchemaBase):
+    __label__ = "Gestionnaire d'Embeds"
+    __description__ = "Création et publication d'embeds personnalisés."
+    __icon__ = "📝"
+    __category__ = "Outils"
+
+    enabled: bool = enabled_field()
+    channelId: str = ui(
+        "Salon de publication",
+        "channel",
+        required=True,
+        description="Salon pour publier les embeds (message créé automatiquement).",
+    )
+    pinMessage: bool = ui(
+        "Épingler le message",
+        "boolean",
+        default=False,
+        description="Épingler automatiquement le message publié.",
+    )
+    messageId: str | None = hidden_message_id("Message cible", "channelId")
+    embeds: list[Any] = ui(
+        "Embeds",
+        "embedlist",
+        description="Créez des embeds avec un titre, couleur et liens.",
+        default=[],
+    )
+
 
 logger = logutil.init_logger(os.path.basename(__file__))
 

--- a/extensions/minecraftext.py
+++ b/extensions/minecraftext.py
@@ -44,6 +44,96 @@ from src.helpers import (
 )
 from src.minecraft_config import get_config as get_mc_config
 from src.utils import create_dynamic_image, load_config
+from src.webui.schemas import (
+    SchemaBase,
+    enabled_field,
+    hidden_message_id,
+    register_module,
+    secret_field,
+    ui,
+)
+
+
+@register_module("moduleMinecraft")
+class MinecraftConfig(SchemaBase):
+    __label__ = "Minecraft"
+    __description__ = "Statut et gestion du serveur Minecraft via RCON."
+    __icon__ = "⛏️"
+    __category__ = "Esport & Jeux"
+
+    enabled: bool = enabled_field()
+    minecraftChannelId: str = ui(
+        "Salon statut",
+        "channel",
+        required=True,
+        description="Salon pour le message de statut (créé automatiquement).",
+    )
+    minecraftPinMessage: bool = ui(
+        "Épingler le message de statut",
+        "boolean",
+        default=False,
+        description="Épingler automatiquement le message de statut.",
+    )
+    minecraftMessageId: str | None = hidden_message_id("Message statut", "minecraftChannelId")
+    minecraftUrl: str | None = ui(
+        "URL publique", "string", description="Nom de domaine public du serveur Minecraft."
+    )
+    minecraftIp: str = ui(
+        "IP du serveur", "string", required=True, description="Adresse IP du serveur Minecraft."
+    )
+    minecraftPort: str = ui(
+        "Port du serveur", "string", default="25565", description="Port du serveur Minecraft."
+    )
+    minecraftRconHost: str | None = ui(
+        "Hôte RCON", "string", description="Adresse IP pour la connexion RCON."
+    )
+    minecraftRconPort: int = ui(
+        "Port RCON", "number", default=25575, description="Port RCON du serveur."
+    )
+    minecraftRconPassword: str | None = secret_field(
+        "Mot de passe RCON", description="Mot de passe RCON du serveur."
+    )
+    minecraftSftpHost: str | None = ui(
+        "Hôte SFTP",
+        "string",
+        description="Adresse IP du serveur SFTP (par défaut, même que l'IP du serveur).",
+    )
+    minecraftSftpPort: int = ui(
+        "Port SFTP", "number", default=2225, description="Port du serveur SFTP."
+    )
+    minecraftSftpUsername: str = ui(
+        "Utilisateur SFTP",
+        "string",
+        default="Discord",
+        description="Nom d'utilisateur pour la connexion SFTP.",
+    )
+    minecraftSftpsPassword: str | None = secret_field(
+        "Mot de passe SFTP", description="Mot de passe SFTP pour l'accès aux fichiers."
+    )
+    minecraftModpackName: str | None = ui(
+        "Nom du modpack", "string", description="Nom du modpack Minecraft."
+    )
+    minecraftModpackUrl: str | None = ui(
+        "URL du modpack", "string", description="Lien vers la page du modpack."
+    )
+    minecraftModpackVersion: str | None = ui(
+        "Version du modpack", "string", description="Version actuelle du modpack."
+    )
+    minecraftStatusUrl: str | None = ui(
+        "URL page de statut", "string", description="Lien vers la page de statut du serveur."
+    )
+    minecraftFooterText: str | None = ui(
+        "Texte du footer", "string", description="Texte affiché en bas de l'embed en veille."
+    )
+    minecraftServerType: str | None = ui(
+        "Type de serveur",
+        "string",
+        description=(
+            "Type de serveur affiché dans le titre de l'embed (ex: Forge, Paper, Fabric). "
+            "Laisser vide pour ne pas afficher."
+        ),
+    )
+
 
 # Initialize logger
 logger = logutil.init_logger(os.path.basename(__file__))

--- a/extensions/olympicsext.py
+++ b/extensions/olympicsext.py
@@ -28,6 +28,24 @@ from interactions import (
 from src import logutil
 from src.mongodb import mongo_manager
 from src.utils import load_config
+from src.webui.schemas import SchemaBase, enabled_field, register_module, ui
+
+
+@register_module("moduleOlympics")
+class OlympicsConfig(SchemaBase):
+    __label__ = "Jeux Olympiques"
+    __description__ = "Alertes médailles des Jeux Olympiques."
+    __icon__ = "🏅"
+    __category__ = "Événements"
+
+    enabled: bool = enabled_field()
+    olympicsChannelId: str = ui(
+        "Salon alertes",
+        "channel",
+        required=True,
+        description="Salon pour les alertes de médailles.",
+    )
+
 
 logger = logutil.init_logger(os.path.basename(__file__))
 config, module_config, enabled_servers = load_config("moduleOlympics")

--- a/extensions/satisfactory.py
+++ b/extensions/satisfactory.py
@@ -16,6 +16,50 @@ from pyfactorybridge import API
 from src import logutil
 from src.helpers import fetch_or_create_persistent_message
 from src.utils import load_config
+from src.webui.schemas import (
+    SchemaBase,
+    enabled_field,
+    hidden_message_id,
+    register_module,
+    secret_field,
+    ui,
+)
+
+
+@register_module("moduleSatisfactory")
+class SatisfactoryConfig(SchemaBase):
+    __label__ = "Satisfactory"
+    __description__ = "Statut et gestion du serveur Satisfactory."
+    __icon__ = "🏭"
+    __category__ = "Esport & Jeux"
+
+    enabled: bool = enabled_field()
+    satisfactoryChannelId: str = ui(
+        "Salon statut",
+        "channel",
+        required=True,
+        description="Salon pour le message de statut (créé automatiquement).",
+    )
+    satisfactoryPinMessage: bool = ui(
+        "Épingler le message de statut",
+        "boolean",
+        default=False,
+        description="Épingler automatiquement le message de statut.",
+    )
+    satisfactoryMessageId: str | None = hidden_message_id("Message statut", "satisfactoryChannelId")
+    satisfactoryServerIp: str = ui(
+        "IP du serveur", "string", required=True, description="Adresse IP du serveur Satisfactory."
+    )
+    satisfactoryServerPort: str = ui(
+        "Port du serveur", "string", default="7777", description="Port du serveur Satisfactory."
+    )
+    satisfactoryServerPassword: str | None = secret_field(
+        "Mot de passe serveur", description="Mot de passe du serveur Satisfactory."
+    )
+    satisfactoryServerToken: str | None = secret_field(
+        "Token API serveur", description="Token d'authentification API du serveur."
+    )
+
 
 logger = logutil.init_logger(os.path.basename(__file__))
 

--- a/extensions/speedonsext.py
+++ b/extensions/speedonsext.py
@@ -22,6 +22,54 @@ from interactions.ext import paginators
 from src import logutil
 from src.config_manager import load_config
 from src.helpers import fetch_or_create_persistent_message
+from src.webui.schemas import (
+    SchemaBase,
+    enabled_field,
+    hidden_message_id,
+    register_module,
+    ui,
+)
+
+
+@register_module("moduleSpeedons")
+class SpeedonsConfig(SchemaBase):
+    __label__ = "Speedons"
+    __description__ = "Planning et suivi en temps réel de l'événement Speedons."
+    __icon__ = "🏃"
+    __category__ = "Événements"
+
+    enabled: bool = enabled_field()
+    speedonsChannelId: str = ui(
+        "Salon",
+        "channel",
+        required=True,
+        description="Salon contenant les messages du planning (créés automatiquement).",
+    )
+    speedonsPinMessages: bool = ui(
+        "Épingler les messages",
+        "boolean",
+        default=False,
+        description="Épingler automatiquement les messages planning et live.",
+    )
+    speedonsScheduleMessageId: str | None = hidden_message_id(
+        "Message planning", "speedonsChannelId"
+    )
+    speedonsLiveMessageId: str | None = hidden_message_id(
+        "Message run en cours", "speedonsChannelId"
+    )
+    speedonsApiUrl: str = ui(
+        "URL API",
+        "url",
+        description="URL de base de l'API Speedons (inclut le slug de la campagne).",
+        default="https://tracker.speedons.fr/api/campaigns?slug=2025",
+    )
+    speedonsIconUrl: str = ui(
+        "URL de l'icône",
+        "url",
+        description="URL de l'icône affichée dans les embeds.",
+        default="https://speedons.fr/static/b476f2d8ad4a19d2393eb4cff9486cc9/c6b81/icon.png",
+    )
+
 
 logger = logutil.init_logger(os.path.basename(__file__))
 

--- a/extensions/spotify/_common.py
+++ b/extensions/spotify/_common.py
@@ -10,6 +10,7 @@ import os
 import re
 from datetime import datetime
 from enum import Enum
+from typing import Any
 
 import aiohttp
 import interactions
@@ -20,8 +21,66 @@ from src.config_manager import load_config, load_discord2name
 from src.helpers import Colors
 from src.integrations.spotify import spotify_auth
 from src.mongodb import mongo_manager
+from src.webui.schemas import (
+    SchemaBase,
+    enabled_field,
+    hidden_message_id,
+    register_module,
+    ui,
+)
 
 logger = logutil.init_logger(os.path.basename(__file__))
+
+
+@register_module("moduleSpotify")
+class SpotifyConfig(SchemaBase):
+    __label__ = "Spotify"
+    __description__ = "Suivi des écoutes Spotify et playlists collaboratives."
+    __icon__ = "🎵"
+    __category__ = "Médias & Streaming"
+
+    enabled: bool = enabled_field()
+    voteEnabled: bool = ui(
+        "Votes activés",
+        "boolean",
+        default=False,
+        description="Activer les votes sur les morceaux ajoutés.",
+    )
+    spotifyChannelId: str = ui(
+        "Salon notifications",
+        "channel",
+        required=True,
+        description="Salon pour les notifications d'écoute.",
+    )
+    spotifyPlaylistId: str | None = ui(
+        "Playlist principale", "string", description="ID de la playlist Spotify principale."
+    )
+    spotifyNewPlaylistId: str | None = ui(
+        "Playlist découvertes", "string", description="ID de la playlist de découvertes."
+    )
+    spotifyRecapChannelId: str | None = ui(
+        "Salon message récap",
+        "channel",
+        description="Salon où le message de récap est publié (créé automatiquement).",
+    )
+    spotifyRecapPinMessage: bool = ui(
+        "Épingler le message récap",
+        "boolean",
+        default=False,
+        description="Épingler automatiquement le message de récap de la playlist.",
+    )
+    spotifyRecapMessageId: str | None = hidden_message_id(
+        "ID message récap", "spotifyRecapChannelId"
+    )
+    spotifyUsers: dict[str, Any] = ui(
+        "Mapping Spotify → Discord",
+        "spotifymap",
+        description=(
+            "Associe un ID Spotify à un membre Discord. "
+            "Le prénom affiché vient du mapping « Discord → Prénoms »."
+        ),
+    )
+
 
 config, module_config, enabled_servers = load_config("moduleSpotify")
 

--- a/extensions/streamlabscharityext.py
+++ b/extensions/streamlabscharityext.py
@@ -24,6 +24,43 @@ from src import logutil
 from src.config_manager import load_config
 from src.helpers import fetch_or_create_persistent_message, send_error
 from src.utils import escape_md, fetch
+from src.webui.schemas import (
+    SchemaBase,
+    enabled_field,
+    hidden_message_id,
+    register_module,
+    ui,
+)
+
+
+@register_module("moduleStreamlabsCharity")
+class StreamlabsCharityConfig(SchemaBase):
+    __label__ = "Streamlabs Charity"
+    __description__ = "Suivi d'une campagne Streamlabs Charity en direct."
+    __icon__ = "❤️"
+    __category__ = "Événements"
+
+    enabled: bool = enabled_field()
+    streamlabsChannelId: str = ui(
+        "Salon",
+        "channel",
+        required=True,
+        description="Salon pour le message de suivi (créé automatiquement).",
+    )
+    streamlabsPinMessage: bool = ui(
+        "Épingler le message",
+        "boolean",
+        default=False,
+        description="Épingler automatiquement le message de suivi.",
+    )
+    streamlabsTeamUrl: str = ui(
+        "URL de la team",
+        "url",
+        default="https://streamlabscharity.com/teams/@streamers-4-palestinians/streamers-4-palestinians",
+        description="URL publique de la team Streamlabs Charity.",
+    )
+    streamlabsMessageId: str | None = hidden_message_id("Message suivi", "streamlabsChannelId")
+
 
 logger = logutil.init_logger(os.path.basename(__file__))
 load_dotenv()

--- a/extensions/tricount.py
+++ b/extensions/tricount.py
@@ -22,6 +22,18 @@ from src import logutil
 from src.config_manager import load_config
 from src.helpers import Colors, fetch_user_safe, guild_group_autocomplete, require_guild, send_error
 from src.mongodb import mongo_manager
+from src.webui.schemas import SchemaBase, enabled_field, register_module
+
+
+@register_module("moduleTricount")
+class TricountConfig(SchemaBase):
+    __label__ = "Tricount"
+    __description__ = "Gestion des dépenses partagées."
+    __icon__ = "💰"
+    __category__ = "Outils"
+
+    enabled: bool = enabled_field()
+
 
 logger = logutil.init_logger(os.path.basename(__file__))
 config, module_config, enabled_servers = load_config("moduleTricount")

--- a/extensions/twitch/_common.py
+++ b/extensions/twitch/_common.py
@@ -6,8 +6,30 @@ the package root.
 """
 
 from datetime import datetime
+from typing import Any
 
 import pytz
+
+from src.webui.schemas import SchemaBase, enabled_field, register_module, ui
+
+
+@register_module("moduleTwitch")
+class TwitchConfig(SchemaBase):
+    __label__ = "Twitch"
+    __description__ = "Notifications de live et planning des streamers."
+    __icon__ = "📺"
+    __category__ = "Médias & Streaming"
+
+    enabled: bool = enabled_field()
+    twitchStreamerList: dict[str, Any] = ui(
+        "Streamers suivis",
+        "streamermap",
+        required=True,
+        description=(
+            "Liste des streamers Twitch à suivre. "
+            "Chaque streamer a ses propres salons et préférences de notifications."
+        ),
+    )
 
 
 def ensure_utc(dt: datetime | None) -> datetime | None:

--- a/extensions/utilext.py
+++ b/extensions/utilext.py
@@ -56,6 +56,18 @@ from src.config_manager import load_config
 from src.helpers import Colors, fetch_user_safe, is_guild_enabled, send_error
 from src.mongodb import mongo_manager
 from src.utils import format_poll
+from src.webui.schemas import SchemaBase, enabled_field, register_module
+
+
+@register_module("moduleUtils")
+class UtilsConfig(SchemaBase):
+    __label__ = "Utilitaires"
+    __description__ = "Commandes utilitaires : ping, sondages, rappels, suppression de messages."
+    __icon__ = "🛠️"
+    __category__ = "Outils"
+
+    enabled: bool = enabled_field()
+
 
 logger = logutil.init_logger(os.path.basename(__file__))
 config, module_config, enabled_servers = load_config("moduleUtils")

--- a/extensions/vlrgg_tracker.py
+++ b/extensions/vlrgg_tracker.py
@@ -44,6 +44,30 @@ from src.vlrgg import (
 from src.vlrgg import (
     fetch_all_team_data as vlrgg_fetch_all,
 )
+from src.webui.schemas import SchemaBase, enabled_field, register_module, ui
+
+
+@register_module("moduleVlrgg")
+class VlrggConfig(SchemaBase):
+    __label__ = "Esport Tracker (VLR.gg)"
+    __description__ = "Suivi automatique des matchs d'équipes Valorant via VLR.gg."
+    __icon__ = "🎮"
+    __category__ = "Esport & Jeux"
+
+    enabled: bool = enabled_field()
+    notificationChannelId: str | None = ui(
+        "Salon notifications",
+        "channel",
+        description="Salon pour les notifications de matchs en direct et résultats.",
+    )
+    teams: list[Any] = ui(
+        "Équipes suivies",
+        "teams",
+        description=(
+            "Liste des équipes Valorant à suivre. Chaque équipe nécessite un nom et un ID VLR.gg."
+        ),
+    )
+
 
 logger = logutil.init_logger(os.path.basename(__file__))
 config, module_config, enabled_servers = load_config("moduleVlrgg")

--- a/extensions/welcome.py
+++ b/extensions/welcome.py
@@ -8,6 +8,40 @@ from interactions.api.events import MemberAdd, MemberRemove
 from src import logutil
 from src.config_manager import load_config
 from src.helpers import is_guild_enabled, pick_weighted_message
+from src.webui.schemas import SchemaBase, enabled_field, register_module, ui
+
+
+@register_module("moduleWelcome")
+class WelcomeConfig(SchemaBase):
+    __label__ = "Bienvenue"
+    __description__ = "Messages de bienvenue et de départ."
+    __icon__ = "👋"
+    __category__ = "Communauté"
+
+    enabled: bool = enabled_field()
+    welcomeChannelId: str = ui(
+        "Salon de bienvenue",
+        "channel",
+        required=True,
+        description="Salon où les messages de bienvenue sont envoyés.",
+    )
+    welcomeMessageList: list[str] = ui(
+        "Messages de bienvenue",
+        "messagelist",
+        description="Liste de messages avec poids de probabilité.",
+        default=["Bienvenue {mention} !"],
+        weight_field="welcomeMessageWeights",
+        variables="{mention}",
+    )
+    leaveMessageList: list[str] = ui(
+        "Messages de départ",
+        "messagelist",
+        description="Liste de messages de départ avec poids de probabilité.",
+        default=["{username} nous a quittés."],
+        weight_field="leaveMessageWeights",
+        variables="{username}",
+    )
+
 
 logger = logutil.init_logger(os.path.basename(__file__))
 

--- a/extensions/xpext.py
+++ b/extensions/xpext.py
@@ -41,6 +41,44 @@ from src.helpers import (
 )
 from src.mongodb import mongo_manager
 from src.utils import CustomPaginator, format_number
+from src.webui.schemas import (
+    SchemaBase,
+    enabled_field,
+    hidden_message_id,
+    register_module,
+    ui,
+)
+
+
+@register_module("moduleXp")
+class XpConfig(SchemaBase):
+    __label__ = "Système d'XP"
+    __description__ = "Système de niveaux et d'expérience."
+    __icon__ = "⭐"
+    __category__ = "Communauté"
+
+    enabled: bool = enabled_field()
+    xpChannelId: str | None = ui(
+        "Salon leaderboard",
+        "channel",
+        description="Salon pour le leaderboard permanent (créé automatiquement).",
+    )
+    xpPinMessage: bool = ui(
+        "Épingler le leaderboard",
+        "boolean",
+        default=False,
+        description="Épingler automatiquement le message du leaderboard.",
+    )
+    xpMessageId: str | None = hidden_message_id("Message leaderboard", "xpChannelId")
+    levelUpMessageList: list[str] = ui(
+        "Messages de level-up",
+        "messagelist",
+        description="Liste de messages avec poids de probabilité.",
+        default=["Bravo {mention}, tu as atteint le niveau {lvl} !"],
+        weight_field="levelUpMessageWeights",
+        variables="{mention}, {lvl}",
+    )
+
 
 logger = logutil.init_logger(os.path.basename(__file__))
 config, module_config, enabled_servers = load_config("moduleXp")

--- a/extensions/youtubeext.py
+++ b/extensions/youtubeext.py
@@ -11,6 +11,30 @@ from src import logutil
 from src.config_manager import load_config
 from src.mongodb import mongo_manager
 from src.utils import fetch
+from src.webui.schemas import SchemaBase, enabled_field, register_module, ui
+
+
+@register_module("moduleYoutube")
+class YoutubeConfig(SchemaBase):
+    __label__ = "YouTube"
+    __description__ = "Notifications de nouvelles vidéos YouTube."
+    __icon__ = "▶️"
+    __category__ = "Médias & Streaming"
+
+    enabled: bool = enabled_field()
+    ChannelId: str = ui(
+        "Salon notifications",
+        "channel",
+        required=True,
+        description="Salon pour les notifications de nouvelles vidéos.",
+    )
+    youtubeChannelList: list[str] = ui(
+        "Chaînes YouTube",
+        "list",
+        required=True,
+        description="Liste des noms de chaînes YouTube à surveiller.",
+    )
+
 
 logger = logutil.init_logger(os.path.basename(__file__))
 config, module_config, enabled_servers = load_config("moduleYoutube")

--- a/extensions/zevent/_common.py
+++ b/extensions/zevent/_common.py
@@ -6,8 +6,72 @@ from datetime import UTC, datetime
 
 from src import logutil
 from src.utils import load_config
+from src.webui.schemas import (
+    SchemaBase,
+    enabled_field,
+    hidden_message_id,
+    register_module,
+    ui,
+)
 
 logger = logutil.init_logger(os.path.basename(__file__))
+
+
+@register_module("moduleZevent")
+class ZeventConfig(SchemaBase):
+    __label__ = "Zevent"
+    __description__ = "Suivi de l'événement Zevent en temps réel (dons, planning, streamers)."
+    __icon__ = "🎉"
+    __category__ = "Événements"
+
+    enabled: bool = enabled_field()
+    zeventChannelId: str = ui(
+        "Salon",
+        "channel",
+        required=True,
+        description="Salon où le message de suivi est posté (créé automatiquement).",
+    )
+    zeventPinMessage: bool = ui(
+        "Épingler le message de suivi",
+        "boolean",
+        default=False,
+        description="Épingler automatiquement le message de suivi.",
+    )
+    zeventMessageId: str | None = hidden_message_id("Message", "zeventChannelId")
+    zeventStreamlabsApiUrl: str = ui(
+        "URL Streamlabs",
+        "url",
+        description="URL de l'API Streamlabs Charity pour les dons.",
+        default="https://streamlabscharity.com/api/v1/teams/@zevent-2025/zevent-2025",
+    )
+    zeventEventStartDate: str = ui(
+        "Début de l'événement",
+        "string",
+        description=(
+            "Date/heure de début du concert pré-événement "
+            "(ISO 8601, ex: 2025-09-04T17:55:00+00:00)."
+        ),
+        default="2025-09-04T17:55:00+00:00",
+    )
+    zeventMainEventStartDate: str = ui(
+        "Début du Zevent",
+        "string",
+        description="Date/heure de début du Zevent principal (ISO 8601).",
+        default="2025-09-05T16:00:00+00:00",
+    )
+    zeventUpdateInterval: int = ui(
+        "Intervalle de mise à jour (secondes)",
+        "number",
+        description="Fréquence de mise à jour du message en secondes. Nécessite un redémarrage.",
+        default=30,
+    )
+    zeventMilestoneInterval: int = ui(
+        "Intervalle des paliers (dons)",
+        "number",
+        description="Montant entre chaque notification de palier de dons.",
+        default=100000,
+    )
+
 
 config, _module_config, _enabled_servers = load_config("moduleZevent")
 _cfg = _module_config.get(_enabled_servers[0], {}) if _enabled_servers else {}

--- a/features/birthday/__init__.py
+++ b/features/birthday/__init__.py
@@ -1,7 +1,43 @@
 from features.birthday.models import BirthdayEntry, _safe_replace_year, _strip_year_from_format
 from features.birthday.repository import BirthdayRepository
+from src.webui.schemas import SchemaBase, enabled_field, register_module, ui
+
+
+@register_module("moduleBirthday")
+class BirthdayConfig(SchemaBase):
+    __label__ = "Anniversaires"
+    __description__ = "Envoie des messages d'anniversaire automatiques."
+    __icon__ = "🎂"
+    __category__ = "Communauté"
+
+    enabled: bool = enabled_field()
+    birthdayChannelId: str = ui(
+        "Salon des anniversaires",
+        "channel",
+        required=True,
+        description="Le salon où les messages d'anniversaire seront envoyés.",
+    )
+    birthdayRoleId: str | None = ui(
+        "Rôle anniversaire", "role", description="Rôle attribué le jour de l'anniversaire."
+    )
+    birthdayGuildLocale: str = ui(
+        "Locale",
+        "string",
+        default="en_US",
+        description="Locale pour le format de date (ex: fr_FR, en_US).",
+    )
+    birthdayMessageList: list[str] = ui(
+        "Messages d'anniversaire",
+        "messagelist",
+        description="Liste de messages avec poids de probabilité.",
+        default=["Joyeux anniversaire {mention} ! 🎉"],
+        weight_field="birthdayMessageWeights",
+        variables="{mention}, {age}",
+    )
+
 
 __all__ = [
+    "BirthdayConfig",
     "BirthdayEntry",
     "BirthdayRepository",
     "_safe_replace_year",

--- a/features/feur/__init__.py
+++ b/features/feur/__init__.py
@@ -1,4 +1,16 @@
 from features.feur.models import FeurStats
 from features.feur.repository import FeurRepository
+from src.webui.schemas import SchemaBase, enabled_field, register_module
 
-__all__ = ["FeurStats", "FeurRepository"]
+
+@register_module("moduleFeur")
+class FeurConfig(SchemaBase):
+    __label__ = "Feur"
+    __description__ = "Répond automatiquement « feur » aux messages se terminant par « quoi »."
+    __icon__ = "😏"
+    __category__ = "Communauté"
+
+    enabled: bool = enabled_field()
+
+
+__all__ = ["FeurConfig", "FeurRepository", "FeurStats"]

--- a/features/secretsanta/__init__.py
+++ b/features/secretsanta/__init__.py
@@ -5,8 +5,21 @@ from features.secretsanta.assignments import (
 )
 from features.secretsanta.models import SecretSantaSession
 from features.secretsanta.repository import SecretSantaRepository
+from src.webui.schemas import SchemaBase, enabled_field, register_module
+
+
+@register_module("moduleSecretSanta")
+class SecretSantaConfig(SchemaBase):
+    __label__ = "Secret Santa"
+    __description__ = "Organisation du Secret Santa."
+    __icon__ = "🎅"
+    __category__ = "Événements"
+
+    enabled: bool = enabled_field()
+
 
 __all__ = [
+    "SecretSantaConfig",
     "SecretSantaRepository",
     "SecretSantaSession",
     "generate_assignments_with_subgroups",

--- a/features/uptime/__init__.py
+++ b/features/uptime/__init__.py
@@ -1,9 +1,22 @@
 from features.uptime.models import STATUS_MAP, MonitorConfig, normalize_status
 from features.uptime.repository import UptimeRepository
+from src.webui.schemas import SchemaBase, enabled_field, register_module
+
+
+@register_module("moduleUptime")
+class UptimeConfig(SchemaBase):
+    __label__ = "Uptime Kuma"
+    __description__ = "Intégration Uptime Kuma pour le monitoring."
+    __icon__ = "📡"
+    __category__ = "Outils"
+
+    enabled: bool = enabled_field()
+
 
 __all__ = [
     "MonitorConfig",
     "STATUS_MAP",
+    "UptimeConfig",
     "UptimeRepository",
     "normalize_status",
 ]

--- a/src/webui/schemas.py
+++ b/src/webui/schemas.py
@@ -1,984 +1,418 @@
 """
-Module configuration schemas.
+UI configuration schemas for the Web UI.
 
-Defines the expected configuration fields for each bot module,
-both for per-server config and global config sections.
-This is used by the Web UI to render proper forms instead of raw JSON editors.
+Each per-server module and each global config section is a Pydantic
+``BaseModel`` subclass registered via ``@register_module`` / ``@register_section``.
+Fields attach UI metadata via ``Field(json_schema_extra={"ui": ...})`` built by
+the ``ui()`` helper.
+
+Per-module configs live alongside their owning module (features/<name>/ or
+extensions/<name>/), so this file only owns:
+  - the DSL (``SchemaBase``, ``ui``, helpers, decorators)
+  - the global config sections (discord, mongodb, …)
+  - the ``discord2name`` per-server mapping (no natural owner)
+
+``MODULE_SCHEMAS`` / ``GLOBAL_CONFIG_SCHEMAS`` — the dicts consumed by the
+frontend — are built lazily via module ``__getattr__`` so extensions can
+import the DSL without triggering a circular import.
+
+Recognised widget types (``type=`` on ``ui()``):
+    string, number, boolean, channel, role, message, secret, url,
+    list, list:number, dict, messagelist, embedlist, keyvaluemap,
+    spotifymap, streamermap, teams, discord2name, models.
 """
 
-# Field types used in schemas
-# "string"   — text input
-# "number"   — numeric input
-# "boolean"  — toggle switch
-# "channel"  — Discord channel ID (rendered as text input with hint)
-# "role"     — Discord role ID
-# "message"  — Discord message ID
-# "secret"   — sensitive string (masked in UI)
-# "list"     — list of strings (comma-separated or multi-line)
-# "list:number" — list of numbers
-# "dict"     — nested object (raw JSON editor)
-# "url"      — URL string
-# "messagelist" — list of messages with linked weight field (form rows)
-# "embedlist" — list of embeds with title, color, and links (form rows)
-# "keyvaluemap" — key-value pairs in a form (customizable key/value labels via key_label, value_label)
-# "spotifymap" — list of Spotify user mappings (spotifyId → discordId; name resolved from discord2name / users collection)
-# "streamermap" — dict keyed by Twitch login; each value has planning/notification channel and pin fields
+from typing import Any, ClassVar
+
+from pydantic import BaseModel, ConfigDict, Field
+
+_UNSET = object()
 
 
-def _field(
+# ── DSL ──────────────────────────────────────────────────────────────
+
+
+def ui(
     label: str,
-    field_type: str = "string",
+    type: str = "string",
+    *,
     required: bool = False,
+    default: Any = _UNSET,
     description: str = "",
-    default=None,
     secret: bool = False,
+    hidden: bool = False,
     weight_field: str = "",
+    channel_field: str = "",
     variables: str = "",
     key_label: str = "",
     value_label: str = "",
-    hidden: bool = False,
-    channel_field: str = "",
-):
-    """Helper to create a field definition."""
-    f = {
-        "label": label,
-        "type": field_type,
-        "required": required,
-    }
+) -> Any:
+    """Build a Pydantic ``Field(...)`` carrying UI metadata in ``json_schema_extra['ui']``.
+
+    ``default=_UNSET`` (the sentinel) means "no default declared" — the UI
+    omits the ``default`` key and the Pydantic field defaults to ``None``.
+    """
+    meta: dict[str, Any] = {"label": label, "type": type, "required": required}
     if description:
-        f["description"] = description
-    if default is not None:
-        f["default"] = default
+        meta["description"] = description
+    if default is not _UNSET:
+        meta["default"] = default
     if secret:
-        f["secret"] = True
+        meta["secret"] = True
     if weight_field:
-        f["weightField"] = weight_field
+        meta["weightField"] = weight_field
     if variables:
-        f["variables"] = variables
+        meta["variables"] = variables
     if key_label:
-        f["keyLabel"] = key_label
+        meta["keyLabel"] = key_label
     if value_label:
-        f["valueLabel"] = value_label
+        meta["valueLabel"] = value_label
     if hidden:
-        f["hidden"] = True
+        meta["hidden"] = True
     if channel_field:
-        f["channelField"] = channel_field
-    return f
+        meta["channelField"] = channel_field
+
+    field_default = default if default is not _UNSET else None
+    return Field(default=field_default, json_schema_extra={"ui": meta})
 
 
-# ── Per-server module schemas ────────────────────────────────────────
-# Keys map to the module name used in load_config("moduleXxx")
+class SchemaBase(BaseModel):
+    """Base for UI-schema source models; class vars hold module/section metadata."""
 
-MODULE_SCHEMAS: dict[str, dict] = {
-    "moduleBirthday": {
-        "label": "Anniversaires",
-        "description": "Envoie des messages d'anniversaire automatiques.",
-        "icon": "🎂",
-        "category": "Communauté",
-        "fields": {
-            "enabled": _field("Activé", "boolean", default=False),
-            "birthdayChannelId": _field(
-                "Salon des anniversaires",
-                "channel",
-                required=True,
-                description="Le salon où les messages d'anniversaire seront envoyés.",
-            ),
-            "birthdayRoleId": _field(
-                "Rôle anniversaire", "role", description="Rôle attribué le jour de l'anniversaire."
-            ),
-            "birthdayGuildLocale": _field(
-                "Locale",
-                "string",
-                default="en_US",
-                description="Locale pour le format de date (ex: fr_FR, en_US).",
-            ),
-            "birthdayMessageList": _field(
-                "Messages d'anniversaire",
-                "messagelist",
-                description="Liste de messages avec poids de probabilité.",
-                default=["Joyeux anniversaire {mention} ! 🎉"],
-                weight_field="birthdayMessageWeights",
-                variables="{mention}, {age}",
-            ),
-        },
-    },
-    "moduleColoc": {
-        "label": "Colocation",
-        "description": "Gestion de la colocation et notifications Zunivers.",
-        "icon": "🏠",
-        "category": "Communauté",
-        "fields": {
-            "enabled": _field("Activé", "boolean", default=False),
-            "colocZuniversChannelId": _field(
-                "Salon Zunivers", "channel", description="Salon pour les notifications Zunivers."
-            ),
-        },
-    },
-    "moduleIA": {
-        "label": "Intelligence Artificielle",
-        "description": "Comparaison de modèles IA via OpenRouter.",
-        "icon": "🤖",
-        "category": "Outils",
-        "fields": {
-            "enabled": _field("Activé", "boolean", default=False),
-        },
-    },
-    "moduleConfrerie": {
-        "label": "Confrérie",
-        "description": "Intégration Notion pour la Confrérie des Traducteurs.",
-        "icon": "📚",
-        "category": "Outils",
-        "fields": {
-            "enabled": _field("Activé", "boolean", default=False),
-            "confrerieNotionDbOeuvresId": _field(
-                "Notion DB Œuvres",
-                "string",
-                required=True,
-                description="ID de la base de données Notion pour les œuvres.",
-            ),
-            "confrerieNotionDbIdEditorsId": _field(
-                "Notion DB Éditeurs",
-                "string",
-                description="ID de la base de données Notion pour les éditeurs.",
-            ),
-            "confrerieRecapChannelId": _field(
-                "Salon récap",
-                "channel",
-                description="Salon pour le message de récapitulatif (créé automatiquement).",
-            ),
-            "confrerieRecapPinMessage": _field(
-                "Épingler le message récap",
-                "boolean",
-                default=False,
-                description="Épingler automatiquement le message de récap.",
-            ),
-            "confrerieRecapMessageId": _field(
-                "Message récap",
-                "message",
-                hidden=True,
-                channel_field="confrerieRecapChannelId",
-                description="ID interne (géré automatiquement).",
-            ),
-            "confrerieDefiChannelId": _field(
-                "Salon défis", "channel", description="Salon pour les défis de traduction."
-            ),
-            "confrerieNewTextChannelId": _field(
-                "Salon nouveaux textes",
-                "channel",
-                description="Salon pour les notifications de nouveaux textes.",
-            ),
-            "confrerieOwnerId": _field(
-                "ID propriétaire",
-                "string",
-                description="ID Discord du propriétaire de la confrérie.",
-            ),
-        },
-    },
-    "moduleFeur": {
-        "label": "Feur",
-        "description": "Répond automatiquement « feur » aux messages se terminant par « quoi ».",
-        "icon": "😏",
-        "category": "Communauté",
-        "fields": {
-            "enabled": _field("Activé", "boolean", default=False),
-        },
-    },
-    "moduleVlrgg": {
-        "label": "Esport Tracker (VLR.gg)",
-        "description": "Suivi automatique des matchs d'équipes Valorant via VLR.gg.",
-        "icon": "🎮",
-        "category": "Esport & Jeux",
-        "fields": {
-            "enabled": _field("Activé", "boolean", default=False),
-            "notificationChannelId": _field(
-                "Salon notifications",
-                "channel",
-                description="Salon pour les notifications de matchs en direct et résultats.",
-            ),
-            "teams": _field(
-                "Équipes suivies",
-                "teams",
-                description="Liste des équipes Valorant à suivre. Chaque équipe nécessite un nom et un ID VLR.gg.",
-            ),
-        },
-    },
-    "moduleOlympics": {
-        "label": "Jeux Olympiques",
-        "description": "Alertes médailles des Jeux Olympiques.",
-        "icon": "🏅",
-        "category": "Événements",
-        "fields": {
-            "enabled": _field("Activé", "boolean", default=False),
-            "olympicsChannelId": _field(
-                "Salon alertes",
-                "channel",
-                required=True,
-                description="Salon pour les alertes de médailles.",
-            ),
-        },
-    },
-    "moduleSatisfactory": {
-        "label": "Satisfactory",
-        "description": "Statut et gestion du serveur Satisfactory.",
-        "icon": "🏭",
-        "category": "Esport & Jeux",
-        "fields": {
-            "enabled": _field("Activé", "boolean", default=False),
-            "satisfactoryChannelId": _field(
-                "Salon statut",
-                "channel",
-                required=True,
-                description="Salon pour le message de statut (créé automatiquement).",
-            ),
-            "satisfactoryPinMessage": _field(
-                "Épingler le message de statut",
-                "boolean",
-                default=False,
-                description="Épingler automatiquement le message de statut.",
-            ),
-            "satisfactoryMessageId": _field(
-                "Message statut",
-                "message",
-                hidden=True,
-                channel_field="satisfactoryChannelId",
-                description="ID interne (géré automatiquement).",
-            ),
-            "satisfactoryServerIp": _field(
-                "IP du serveur",
-                "string",
-                required=True,
-                description="Adresse IP du serveur Satisfactory.",
-            ),
-            "satisfactoryServerPort": _field(
-                "Port du serveur",
-                "string",
-                default="7777",
-                description="Port du serveur Satisfactory.",
-            ),
-            "satisfactoryServerPassword": _field(
-                "Mot de passe serveur",
-                "secret",
-                description="Mot de passe du serveur Satisfactory.",
-                secret=True,
-            ),
-            "satisfactoryServerToken": _field(
-                "Token API serveur",
-                "secret",
-                description="Token d'authentification API du serveur.",
-                secret=True,
-            ),
-        },
-    },
-    "moduleSecretSanta": {
-        "label": "Secret Santa",
-        "description": "Organisation du Secret Santa.",
-        "icon": "🎅",
-        "category": "Événements",
-        "fields": {
-            "enabled": _field("Activé", "boolean", default=False),
-        },
-    },
-    "moduleSpotify": {
-        "label": "Spotify",
-        "description": "Suivi des écoutes Spotify et playlists collaboratives.",
-        "icon": "🎵",
-        "category": "Médias & Streaming",
-        "fields": {
-            "enabled": _field("Activé", "boolean", default=False),
-            "voteEnabled": _field(
-                "Votes activés",
-                "boolean",
-                default=False,
-                description="Activer les votes sur les morceaux ajoutés.",
-            ),
-            "spotifyChannelId": _field(
-                "Salon notifications",
-                "channel",
-                required=True,
-                description="Salon pour les notifications d'écoute.",
-            ),
-            "spotifyPlaylistId": _field(
-                "Playlist principale", "string", description="ID de la playlist Spotify principale."
-            ),
-            "spotifyNewPlaylistId": _field(
-                "Playlist découvertes", "string", description="ID de la playlist de découvertes."
-            ),
-            "spotifyRecapChannelId": _field(
-                "Salon message récap",
-                "channel",
-                description="Salon où le message de récap est publié (créé automatiquement).",
-            ),
-            "spotifyRecapPinMessage": _field(
-                "Épingler le message récap",
-                "boolean",
-                default=False,
-                description="Épingler automatiquement le message de récap de la playlist.",
-            ),
-            "spotifyRecapMessageId": _field(
-                "ID message récap",
-                "message",
-                hidden=True,
-                channel_field="spotifyRecapChannelId",
-                description="ID interne (géré automatiquement).",
-            ),
-            "spotifyUsers": _field(
-                "Mapping Spotify → Discord",
-                "spotifymap",
-                description="Associe un ID Spotify à un membre Discord. Le prénom affiché vient du mapping « Discord → Prénoms ».",
-            ),
-        },
-    },
-    "moduleTricount": {
-        "label": "Tricount",
-        "description": "Gestion des dépenses partagées.",
-        "icon": "💰",
-        "category": "Outils",
-        "fields": {
-            "enabled": _field("Activé", "boolean", default=False),
-        },
-    },
-    "moduleTwitch": {
-        "label": "Twitch",
-        "description": "Notifications de live et planning des streamers.",
-        "icon": "📺",
-        "category": "Médias & Streaming",
-        "fields": {
-            "enabled": _field("Activé", "boolean", default=False),
-            "twitchStreamerList": _field(
-                "Streamers suivis",
-                "streamermap",
-                required=True,
-                description="Liste des streamers Twitch à suivre. Chaque streamer a ses propres salons et préférences de notifications.",
-            ),
-        },
-    },
-    "moduleUptime": {
-        "label": "Uptime Kuma",
-        "description": "Intégration Uptime Kuma pour le monitoring.",
-        "icon": "📡",
-        "category": "Outils",
-        "fields": {
-            "enabled": _field("Activé", "boolean", default=False),
-        },
-    },
-    "moduleUtils": {
-        "label": "Utilitaires",
-        "description": "Commandes utilitaires : ping, sondages, rappels, suppression de messages.",
-        "icon": "🛠️",
-        "category": "Outils",
-        "fields": {
-            "enabled": _field("Activé", "boolean", default=False),
-        },
-    },
-    "moduleWelcome": {
-        "label": "Bienvenue",
-        "description": "Messages de bienvenue et de départ.",
-        "icon": "👋",
-        "category": "Communauté",
-        "fields": {
-            "enabled": _field("Activé", "boolean", default=False),
-            "welcomeChannelId": _field(
-                "Salon de bienvenue",
-                "channel",
-                required=True,
-                description="Salon où les messages de bienvenue sont envoyés.",
-            ),
-            "welcomeMessageList": _field(
-                "Messages de bienvenue",
-                "messagelist",
-                description="Liste de messages avec poids de probabilité.",
-                default=["Bienvenue {mention} !"],
-                weight_field="welcomeMessageWeights",
-                variables="{mention}",
-            ),
-            "leaveMessageList": _field(
-                "Messages de départ",
-                "messagelist",
-                description="Liste de messages de départ avec poids de probabilité.",
-                default=["{username} nous a quittés."],
-                weight_field="leaveMessageWeights",
-                variables="{username}",
-            ),
-        },
-    },
-    "moduleXp": {
-        "label": "Système d'XP",
-        "description": "Système de niveaux et d'expérience.",
-        "icon": "⭐",
-        "category": "Communauté",
-        "fields": {
-            "enabled": _field("Activé", "boolean", default=False),
-            "xpChannelId": _field(
-                "Salon leaderboard",
-                "channel",
-                description="Salon pour le leaderboard permanent (créé automatiquement).",
-            ),
-            "xpPinMessage": _field(
-                "Épingler le leaderboard",
-                "boolean",
-                default=False,
-                description="Épingler automatiquement le message du leaderboard.",
-            ),
-            "xpMessageId": _field(
-                "Message leaderboard",
-                "message",
-                hidden=True,
-                channel_field="xpChannelId",
-                description="ID interne (géré automatiquement).",
-            ),
-            "levelUpMessageList": _field(
-                "Messages de level-up",
-                "messagelist",
-                description="Liste de messages avec poids de probabilité.",
-                default=["Bravo {mention}, tu as atteint le niveau {lvl} !"],
-                weight_field="levelUpMessageWeights",
-                variables="{mention}, {lvl}",
-            ),
-        },
-    },
-    "moduleYoutube": {
-        "label": "YouTube",
-        "description": "Notifications de nouvelles vidéos YouTube.",
-        "icon": "▶️",
-        "category": "Médias & Streaming",
-        "fields": {
-            "enabled": _field("Activé", "boolean", default=False),
-            "ChannelId": _field(
-                "Salon notifications",
-                "channel",
-                required=True,
-                description="Salon pour les notifications de nouvelles vidéos.",
-            ),
-            "youtubeChannelList": _field(
-                "Chaînes YouTube",
-                "list",
-                required=True,
-                description="Liste des noms de chaînes YouTube à surveiller.",
-            ),
-        },
-    },
-    "moduleMinecraft": {
-        "label": "Minecraft",
-        "description": "Statut et gestion du serveur Minecraft via RCON.",
-        "icon": "⛏️",
-        "category": "Esport & Jeux",
-        "fields": {
-            "enabled": _field("Activé", "boolean", default=False),
-            "minecraftChannelId": _field(
-                "Salon statut",
-                "channel",
-                required=True,
-                description="Salon pour le message de statut (créé automatiquement).",
-            ),
-            "minecraftPinMessage": _field(
-                "Épingler le message de statut",
-                "boolean",
-                default=False,
-                description="Épingler automatiquement le message de statut.",
-            ),
-            "minecraftMessageId": _field(
-                "Message statut",
-                "message",
-                hidden=True,
-                channel_field="minecraftChannelId",
-                description="ID interne (géré automatiquement).",
-            ),
-            "minecraftUrl": _field(
-                "URL publique", "string", description="Nom de domaine public du serveur Minecraft."
-            ),
-            "minecraftIp": _field(
-                "IP du serveur",
-                "string",
-                required=True,
-                description="Adresse IP du serveur Minecraft.",
-            ),
-            "minecraftPort": _field(
-                "Port du serveur",
-                "string",
-                default="25565",
-                description="Port du serveur Minecraft.",
-            ),
-            "minecraftRconHost": _field(
-                "Hôte RCON", "string", description="Adresse IP pour la connexion RCON."
-            ),
-            "minecraftRconPort": _field(
-                "Port RCON", "number", default=25575, description="Port RCON du serveur."
-            ),
-            "minecraftRconPassword": _field(
-                "Mot de passe RCON",
-                "secret",
-                description="Mot de passe RCON du serveur.",
-                secret=True,
-            ),
-            "minecraftSftpHost": _field(
-                "Hôte SFTP",
-                "string",
-                description="Adresse IP du serveur SFTP (par défaut, même que l'IP du serveur).",
-            ),
-            "minecraftSftpPort": _field(
-                "Port SFTP", "number", default=2225, description="Port du serveur SFTP."
-            ),
-            "minecraftSftpUsername": _field(
-                "Utilisateur SFTP",
-                "string",
-                default="Discord",
-                description="Nom d'utilisateur pour la connexion SFTP.",
-            ),
-            "minecraftSftpsPassword": _field(
-                "Mot de passe SFTP",
-                "secret",
-                description="Mot de passe SFTP pour l'accès aux fichiers.",
-                secret=True,
-            ),
-            "minecraftModpackName": _field(
-                "Nom du modpack", "string", description="Nom du modpack Minecraft."
-            ),
-            "minecraftModpackUrl": _field(
-                "URL du modpack", "string", description="Lien vers la page du modpack."
-            ),
-            "minecraftModpackVersion": _field(
-                "Version du modpack", "string", description="Version actuelle du modpack."
-            ),
-            "minecraftStatusUrl": _field(
-                "URL page de statut",
-                "string",
-                description="Lien vers la page de statut du serveur.",
-            ),
-            "minecraftFooterText": _field(
-                "Texte du footer",
-                "string",
-                description="Texte affiché en bas de l'embed en veille.",
-            ),
-            "minecraftServerType": _field(
-                "Type de serveur",
-                "string",
-                description="Type de serveur affiché dans le titre de l'embed (ex: Forge, Paper, Fabric). Laisser vide pour ne pas afficher.",
-            ),
-        },
-    },
-    "moduleZevent": {
-        "label": "Zevent",
-        "description": "Suivi de l'événement Zevent en temps réel (dons, planning, streamers).",
-        "icon": "🎉",
-        "category": "Événements",
-        "fields": {
-            "enabled": _field("Activé", "boolean", default=False),
-            "zeventChannelId": _field(
-                "Salon",
-                "channel",
-                required=True,
-                description="Salon où le message de suivi est posté (créé automatiquement).",
-            ),
-            "zeventPinMessage": _field(
-                "Épingler le message de suivi",
-                "boolean",
-                default=False,
-                description="Épingler automatiquement le message de suivi.",
-            ),
-            "zeventMessageId": _field(
-                "Message",
-                "message",
-                hidden=True,
-                channel_field="zeventChannelId",
-                description="ID interne (géré automatiquement).",
-            ),
-            "zeventStreamlabsApiUrl": _field(
-                "URL Streamlabs",
-                "url",
-                description="URL de l'API Streamlabs Charity pour les dons.",
-                default="https://streamlabscharity.com/api/v1/teams/@zevent-2025/zevent-2025",
-            ),
-            "zeventEventStartDate": _field(
-                "Début de l'événement",
-                "string",
-                description="Date/heure de début du concert pré-événement (ISO 8601, ex: 2025-09-04T17:55:00+00:00).",
-                default="2025-09-04T17:55:00+00:00",
-            ),
-            "zeventMainEventStartDate": _field(
-                "Début du Zevent",
-                "string",
-                description="Date/heure de début du Zevent principal (ISO 8601).",
-                default="2025-09-05T16:00:00+00:00",
-            ),
-            "zeventUpdateInterval": _field(
-                "Intervalle de mise à jour (secondes)",
-                "number",
-                description="Fréquence de mise à jour du message en secondes. Nécessite un redémarrage.",
-                default=30,
-            ),
-            "zeventMilestoneInterval": _field(
-                "Intervalle des paliers (dons)",
-                "number",
-                description="Montant entre chaque notification de palier de dons.",
-                default=100000,
-            ),
-        },
-    },
-    "moduleSpeedons": {
-        "label": "Speedons",
-        "description": "Planning et suivi en temps réel de l'événement Speedons.",
-        "icon": "🏃",
-        "category": "Événements",
-        "fields": {
-            "enabled": _field("Activé", "boolean", default=False),
-            "speedonsChannelId": _field(
-                "Salon",
-                "channel",
-                required=True,
-                description="Salon contenant les messages du planning (créés automatiquement).",
-            ),
-            "speedonsPinMessages": _field(
-                "Épingler les messages",
-                "boolean",
-                default=False,
-                description="Épingler automatiquement les messages planning et live.",
-            ),
-            "speedonsScheduleMessageId": _field(
-                "Message planning",
-                "message",
-                hidden=True,
-                channel_field="speedonsChannelId",
-                description="ID interne (géré automatiquement).",
-            ),
-            "speedonsLiveMessageId": _field(
-                "Message run en cours",
-                "message",
-                hidden=True,
-                channel_field="speedonsChannelId",
-                description="ID interne (géré automatiquement).",
-            ),
-            "speedonsApiUrl": _field(
-                "URL API",
-                "url",
-                description="URL de base de l'API Speedons (inclut le slug de la campagne).",
-                default="https://tracker.speedons.fr/api/campaigns?slug=2025",
-            ),
-            "speedonsIconUrl": _field(
-                "URL de l'icône",
-                "url",
-                description="URL de l'icône affichée dans les embeds.",
-                default="https://speedons.fr/static/b476f2d8ad4a19d2393eb4cff9486cc9/c6b81/icon.png",
-            ),
-        },
-    },
-    "moduleStreamlabsCharity": {
-        "label": "Streamlabs Charity",
-        "description": "Suivi d'une campagne Streamlabs Charity en direct.",
-        "icon": "❤️",
-        "category": "Événements",
-        "fields": {
-            "enabled": _field("Activé", "boolean", default=False),
-            "streamlabsChannelId": _field(
-                "Salon",
-                "channel",
-                required=True,
-                description="Salon pour le message de suivi (créé automatiquement).",
-            ),
-            "streamlabsPinMessage": _field(
-                "Épingler le message",
-                "boolean",
-                default=False,
-                description="Épingler automatiquement le message de suivi.",
-            ),
-            "streamlabsTeamUrl": _field(
-                "URL de la team",
-                "url",
-                default="https://streamlabscharity.com/teams/@streamers-4-palestinians/streamers-4-palestinians",
-                description="URL publique de la team Streamlabs Charity.",
-            ),
-            "streamlabsMessageId": _field(
-                "Message suivi",
-                "message",
-                hidden=True,
-                channel_field="streamlabsChannelId",
-                description="ID interne (géré automatiquement).",
-            ),
-        },
-    },
-    "moduleEmbedManager": {
-        "label": "Gestionnaire d'Embeds",
-        "description": "Création et publication d'embeds personnalisés.",
-        "icon": "📝",
-        "category": "Outils",
-        "fields": {
-            "enabled": _field("Activé", "boolean", default=False),
-            "channelId": _field(
-                "Salon de publication",
-                "channel",
-                required=True,
-                description="Salon pour publier les embeds (message créé automatiquement).",
-            ),
-            "pinMessage": _field(
-                "Épingler le message",
-                "boolean",
-                default=False,
-                description="Épingler automatiquement le message publié.",
-            ),
-            "messageId": _field(
-                "Message cible",
-                "message",
-                hidden=True,
-                channel_field="channelId",
-                description="ID interne (géré automatiquement).",
-            ),
-            "embeds": _field(
-                "Embeds",
-                "embedlist",
-                description="Créez des embeds avec un titre, couleur et liens.",
-                default=[],
-            ),
-        },
-    },
-    "discord2name": {
-        "label": "Discord → Prénoms",
-        "description": "Mapping des IDs Discord vers des prénoms pour ce serveur.",
-        "icon": "👤",
-        "category": "Outils",
-        "noToggle": True,
-        "directValue": True,
-        "fields": {
-            "discord2name": _field(
-                "Membres", "discord2name", description="Associez un prénom à chaque ID Discord."
-            ),
-        },
-    },
-}
+    model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
+
+    __label__: ClassVar[str] = ""
+    __description__: ClassVar[str] = ""
+    __icon__: ClassVar[str] = ""
+    __category__: ClassVar[str] = ""
+    __no_toggle__: ClassVar[bool] = False
+    __direct_value__: ClassVar[bool] = False
 
 
-# ── Global config sections schemas ───────────────────────────────────
-# These describe the top-level config sections (not per-server).
+# ── Reusable field fragments (public, used by extensions) ────────────
+_HIDDEN_MSG_DESC = "ID interne (géré automatiquement)."
 
-GLOBAL_CONFIG_SCHEMAS: dict[str, dict] = {
-    "discord": {
-        "label": "Discord",
-        "icon": "💬",
-        "fields": {
-            "botId": _field("Bot ID", "string", description="ID de l'application / bot Discord."),
-            "botToken": _field(
-                "Token du bot",
-                "secret",
-                required=True,
-                description="Token du bot Discord.",
-                secret=True,
-            ),
-            "ownerId": _field(
-                "ID propriétaire", "string", description="ID Discord du propriétaire du bot."
-            ),
-            "devGuildId": _field(
-                "Serveur de développement", "string", description="ID du serveur de développement."
-            ),
-            "devGuildChannelId": _field(
-                "Salon de dev", "channel", description="ID du salon de développement."
-            ),
-        },
-    },
-    "mongodb": {
-        "label": "MongoDB",
-        "icon": "🗃️",
-        "fields": {
-            "url": _field(
-                "URL de connexion",
-                "secret",
-                required=True,
-                description="URL de connexion MongoDB (mongodb://...).",
-                secret=True,
-            ),
-        },
-    },
-    "spotify": {
-        "label": "Spotify",
-        "icon": "🎵",
-        "fields": {
-            "spotifyClientId": _field("Client ID", "string", required=True),
-            "spotifyClientSecret": _field("Client Secret", "secret", required=True, secret=True),
-            "spotifyRedirectUri": _field(
-                "Redirect URI", "url", description="URI de redirection OAuth Spotify."
-            ),
-        },
-    },
-    "twitch": {
-        "label": "Twitch",
-        "icon": "📺",
-        "fields": {
-            "twitchClientId": _field("Client ID", "string", required=True),
-            "twitchClientSecret": _field("Client Secret", "secret", required=True, secret=True),
-        },
-    },
-    "youtube": {
-        "label": "YouTube",
-        "icon": "▶️",
-        "fields": {
-            "youtubeApiKey": _field(
-                "Clé API",
-                "secret",
-                required=True,
-                description="Clé API YouTube Data v3.",
-                secret=True,
-            ),
-        },
-    },
-    "notion": {
-        "label": "Notion",
-        "icon": "📝",
-        "fields": {
-            "notionSecret": _field(
-                "Token secret",
-                "secret",
-                required=True,
-                description="Token d'intégration Notion.",
-                secret=True,
-            ),
-        },
-    },
-    "OpenRouter": {
-        "label": "OpenRouter",
-        "icon": "🤖",
-        "fields": {
-            "openrouterApiKey": _field(
-                "Clé API", "secret", required=True, description="Clé API OpenRouter.", secret=True
-            ),
-            "modelsToCompare": _field(
-                "Modèles à comparer",
-                "number",
-                default=3,
-                description="Nombre de modèles IA à comparer par question.",
-            ),
-            "models": _field(
-                "Modèles IA",
-                "models",
-                description="Liste des modèles IA disponibles pour la comparaison. "
-                "Chaque modèle nécessite un identifiant provider, un model_id OpenRouter et un nom d'affichage.",
-            ),
-        },
-    },
-    "uptimeKuma": {
-        "label": "Uptime Kuma",
-        "icon": "📡",
-        "fields": {
-            "uptimeKumaUrl": _field(
-                "URL", "url", required=True, description="URL de l'instance Uptime Kuma."
-            ),
-            "uptimeKumaUsername": _field("Nom d'utilisateur", "string", required=True),
-            "uptimeKumaPassword": _field("Mot de passe", "secret", required=True, secret=True),
-            "uptimeKuma2FA": _field(
-                "Code 2FA", "string", description="Code 2FA si activé (optionnel)."
-            ),
-            "uptimeKumaToken": _field(
-                "Token push", "secret", description="Token push pour le statut du bot.", secret=True
-            ),
-            "uptimeKumaApiKey": _field(
-                "Clé API", "secret", description="Clé API Uptime Kuma.", secret=True
-            ),
-        },
-    },
-    "misc": {
-        "label": "Divers",
-        "icon": "⚙️",
-        "fields": {
-            "dataFolder": _field(
-                "Dossier de données",
-                "string",
-                default="data",
-                description="Chemin du dossier de données local.",
-            ),
-        },
-    },
-    "shlink": {
-        "label": "Shlink",
-        "icon": "🔗",
-        "fields": {
-            "shlinkApiKey": _field(
-                "Clé API",
-                "secret",
-                required=True,
-                description="Clé API Shlink pour raccourcir les URLs.",
-                secret=True,
-            ),
-        },
-    },
-    "random": {
-        "label": "Random.org",
-        "icon": "🎲",
-        "fields": {
-            "randomOrgApiKey": _field(
-                "Clé API", "secret", required=True, description="Clé API Random.org.", secret=True
-            ),
-        },
-    },
-    "SecretSanta": {
-        "label": "Secret Santa (global)",
-        "icon": "🎅",
-        "fields": {
-            "secretSantaFile": _field(
-                "Fichier de données",
-                "string",
-                description="Chemin du fichier JSON des données Secret Santa.",
-                default="data/secretsanta.json",
-            ),
-            "secretSantaKey": _field(
-                "Clé de chiffrement",
-                "secret",
-                description="Clé utilisée pour le chiffrement des assignations.",
-                secret=True,
-            ),
-        },
-    },
-    "backup": {
-        "label": "Sauvegarde BDD",
-        "icon": "💾",
-        "fields": {
-            "enabled": _field(
-                "Activé",
-                "boolean",
-                default=True,
-                description="Activer la sauvegarde automatique quotidienne.",
-            ),
-            "backupDir": _field(
-                "Dossier de sauvegarde",
-                "string",
-                default="data/backups",
-                description="Chemin du dossier où les sauvegardes sont stockées.",
-            ),
-            "maxBackups": _field(
-                "Nombre de sauvegardes",
-                "number",
-                default=7,
-                description="Nombre de sauvegardes à conserver (les plus anciennes sont supprimées).",
-            ),
-            "backupHour": _field(
-                "Heure de sauvegarde",
-                "number",
-                default=4,
-                description="Heure locale à laquelle la sauvegarde quotidienne est effectuée (0-23).",
-            ),
-        },
-    },
-    "webui": {
-        "label": "Dashboard Web",
-        "icon": "🌐",
-        "fields": {
-            "enabled": _field("Activé", "boolean", default=False),
-            "host": _field(
-                "Hôte",
-                "string",
-                default="0.0.0.0",
-                description="Adresse de liaison du serveur web.",
-            ),
-            "port": _field("Port", "number", default=8080),
-            "baseUrl": _field(
-                "URL de base",
-                "url",
-                required=True,
-                description="URL publique du dashboard (ex: http://monserveur:8080).",
-            ),
-            "clientId": _field("Client ID Discord", "string", required=True),
-            "clientSecret": _field("Client Secret Discord", "secret", required=True, secret=True),
-            "developerUserIds": _field(
-                "Developer User IDs",
-                "list",
-                required=False,
-                description="IDs Discord autorisés à accéder aux pages Extensions et Logs (réservées au développeur).",
-            ),
-        },
-    },
-}
+
+def enabled_field() -> Any:
+    """Standard ``enabled`` boolean toggle (default off)."""
+    return ui("Activé", "boolean", default=False)
+
+
+def hidden_message_id(label: str, channel_key: str) -> Any:
+    """Hidden ``message`` field for an auto-managed persistent message."""
+    return ui(
+        label, "message", hidden=True, channel_field=channel_key, description=_HIDDEN_MSG_DESC
+    )
+
+
+def secret_field(label: str, required: bool = False, description: str = "") -> Any:
+    """Secret string field (masked in the UI)."""
+    return ui(label, "secret", required=required, description=description, secret=True)
+
+
+# ── Registry + lazy aggregation ──────────────────────────────────────
+
+_MODULE_REGISTRY: dict[str, type[SchemaBase]] = {}
+_SECTION_REGISTRY: dict[str, type[SchemaBase]] = {}
+
+
+def register_module(key: str):
+    """Decorator: register a per-server module config class under ``key``."""
+
+    def decorator(cls: type[SchemaBase]) -> type[SchemaBase]:
+        _MODULE_REGISTRY[key] = cls
+        return cls
+
+    return decorator
+
+
+def register_section(key: str):
+    """Decorator: register a global config section class under ``key``."""
+
+    def decorator(cls: type[SchemaBase]) -> type[SchemaBase]:
+        _SECTION_REGISTRY[key] = cls
+        return cls
+
+    return decorator
+
+
+def _fields_of(cls: type[BaseModel]) -> dict[str, dict[str, Any]]:
+    out: dict[str, dict[str, Any]] = {}
+    for name, info in cls.model_fields.items():
+        extra = info.json_schema_extra
+        meta = extra.get("ui") if isinstance(extra, dict) else None
+        if meta:
+            out[name] = dict(meta)
+    return out
+
+
+def _module_dict(cls: type[SchemaBase]) -> dict[str, Any]:
+    d: dict[str, Any] = {"label": cls.__label__}
+    if cls.__description__:
+        d["description"] = cls.__description__
+    if cls.__icon__:
+        d["icon"] = cls.__icon__
+    if cls.__category__:
+        d["category"] = cls.__category__
+    if cls.__no_toggle__:
+        d["noToggle"] = True
+    if cls.__direct_value__:
+        d["directValue"] = True
+    d["fields"] = _fields_of(cls)
+    return d
+
+
+def _section_dict(cls: type[SchemaBase]) -> dict[str, Any]:
+    d: dict[str, Any] = {"label": cls.__label__}
+    if cls.__icon__:
+        d["icon"] = cls.__icon__
+    d["fields"] = _fields_of(cls)
+    return d
+
+
+def __getattr__(name: str) -> Any:  # noqa: PLR0911
+    """Lazy module attributes: rebuild schema dicts from the current registry.
+
+    Using PEP 562 so the dicts always reflect every registered config at the
+    moment they are first imported — typically by ``routes/config.py`` after
+    all extensions have loaded.
+    """
+    if name == "MODULE_SCHEMAS":
+        return {k: _module_dict(cls) for k, cls in _MODULE_REGISTRY.items()}
+    if name == "GLOBAL_CONFIG_SCHEMAS":
+        return {k: _section_dict(cls) for k, cls in _SECTION_REGISTRY.items()}
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+# ── Per-server "module" without an owning extension ──────────────────
+
+
+@register_module("discord2name")
+class Discord2NameConfig(SchemaBase):
+    __label__ = "Discord → Prénoms"
+    __description__ = "Mapping des IDs Discord vers des prénoms pour ce serveur."
+    __icon__ = "👤"
+    __category__ = "Outils"
+    __no_toggle__ = True
+    __direct_value__ = True
+
+    discord2name: dict[str, str] = ui(
+        "Membres", "discord2name", description="Associez un prénom à chaque ID Discord."
+    )
+
+
+# ── Global config section schemas ────────────────────────────────────
+
+
+@register_section("discord")
+class DiscordSection(SchemaBase):
+    __label__ = "Discord"
+    __icon__ = "💬"
+
+    botId: str | None = ui("Bot ID", "string", description="ID de l'application / bot Discord.")
+    botToken: str = secret_field("Token du bot", required=True, description="Token du bot Discord.")
+    ownerId: str | None = ui(
+        "ID propriétaire", "string", description="ID Discord du propriétaire du bot."
+    )
+    devGuildId: str | None = ui(
+        "Serveur de développement", "string", description="ID du serveur de développement."
+    )
+    devGuildChannelId: str | None = ui(
+        "Salon de dev", "channel", description="ID du salon de développement."
+    )
+
+
+@register_section("mongodb")
+class MongodbSection(SchemaBase):
+    __label__ = "MongoDB"
+    __icon__ = "🗃️"
+
+    url: str = secret_field(
+        "URL de connexion", required=True, description="URL de connexion MongoDB (mongodb://...)."
+    )
+
+
+@register_section("spotify")
+class SpotifySection(SchemaBase):
+    __label__ = "Spotify"
+    __icon__ = "🎵"
+
+    spotifyClientId: str = ui("Client ID", "string", required=True)
+    spotifyClientSecret: str = secret_field("Client Secret", required=True)
+    spotifyRedirectUri: str | None = ui(
+        "Redirect URI", "url", description="URI de redirection OAuth Spotify."
+    )
+
+
+@register_section("twitch")
+class TwitchSection(SchemaBase):
+    __label__ = "Twitch"
+    __icon__ = "📺"
+
+    twitchClientId: str = ui("Client ID", "string", required=True)
+    twitchClientSecret: str = secret_field("Client Secret", required=True)
+
+
+@register_section("youtube")
+class YoutubeSection(SchemaBase):
+    __label__ = "YouTube"
+    __icon__ = "▶️"
+
+    youtubeApiKey: str = secret_field(
+        "Clé API", required=True, description="Clé API YouTube Data v3."
+    )
+
+
+@register_section("notion")
+class NotionSection(SchemaBase):
+    __label__ = "Notion"
+    __icon__ = "📝"
+
+    notionSecret: str = secret_field(
+        "Token secret", required=True, description="Token d'intégration Notion."
+    )
+
+
+@register_section("OpenRouter")
+class OpenRouterSection(SchemaBase):
+    __label__ = "OpenRouter"
+    __icon__ = "🤖"
+
+    openrouterApiKey: str = secret_field(
+        "Clé API", required=True, description="Clé API OpenRouter."
+    )
+    modelsToCompare: int = ui(
+        "Modèles à comparer",
+        "number",
+        default=3,
+        description="Nombre de modèles IA à comparer par question.",
+    )
+    models: list[Any] = ui(
+        "Modèles IA",
+        "models",
+        description="Liste des modèles IA disponibles pour la comparaison. "
+        "Chaque modèle nécessite un identifiant provider, un model_id OpenRouter et un nom d'affichage.",
+    )
+
+
+@register_section("uptimeKuma")
+class UptimeKumaSection(SchemaBase):
+    __label__ = "Uptime Kuma"
+    __icon__ = "📡"
+
+    uptimeKumaUrl: str = ui(
+        "URL", "url", required=True, description="URL de l'instance Uptime Kuma."
+    )
+    uptimeKumaUsername: str = ui("Nom d'utilisateur", "string", required=True)
+    uptimeKumaPassword: str = secret_field("Mot de passe", required=True)
+    uptimeKuma2FA: str | None = ui(
+        "Code 2FA", "string", description="Code 2FA si activé (optionnel)."
+    )
+    uptimeKumaToken: str | None = secret_field(
+        "Token push", description="Token push pour le statut du bot."
+    )
+    uptimeKumaApiKey: str | None = secret_field("Clé API", description="Clé API Uptime Kuma.")
+
+
+@register_section("misc")
+class MiscSection(SchemaBase):
+    __label__ = "Divers"
+    __icon__ = "⚙️"
+
+    dataFolder: str = ui(
+        "Dossier de données",
+        "string",
+        default="data",
+        description="Chemin du dossier de données local.",
+    )
+
+
+@register_section("shlink")
+class ShlinkSection(SchemaBase):
+    __label__ = "Shlink"
+    __icon__ = "🔗"
+
+    shlinkApiKey: str = secret_field(
+        "Clé API", required=True, description="Clé API Shlink pour raccourcir les URLs."
+    )
+
+
+@register_section("random")
+class RandomSection(SchemaBase):
+    __label__ = "Random.org"
+    __icon__ = "🎲"
+
+    randomOrgApiKey: str = secret_field("Clé API", required=True, description="Clé API Random.org.")
+
+
+@register_section("SecretSanta")
+class SecretSantaSection(SchemaBase):
+    __label__ = "Secret Santa (global)"
+    __icon__ = "🎅"
+
+    secretSantaFile: str | None = ui(
+        "Fichier de données",
+        "string",
+        description="Chemin du fichier JSON des données Secret Santa.",
+        default="data/secretsanta.json",
+    )
+    secretSantaKey: str | None = secret_field(
+        "Clé de chiffrement", description="Clé utilisée pour le chiffrement des assignations."
+    )
+
+
+@register_section("backup")
+class BackupSection(SchemaBase):
+    __label__ = "Sauvegarde BDD"
+    __icon__ = "💾"
+
+    enabled: bool = ui(
+        "Activé",
+        "boolean",
+        default=True,
+        description="Activer la sauvegarde automatique quotidienne.",
+    )
+    backupDir: str = ui(
+        "Dossier de sauvegarde",
+        "string",
+        default="data/backups",
+        description="Chemin du dossier où les sauvegardes sont stockées.",
+    )
+    maxBackups: int = ui(
+        "Nombre de sauvegardes",
+        "number",
+        default=7,
+        description="Nombre de sauvegardes à conserver (les plus anciennes sont supprimées).",
+    )
+    backupHour: int = ui(
+        "Heure de sauvegarde",
+        "number",
+        default=4,
+        description="Heure locale à laquelle la sauvegarde quotidienne est effectuée (0-23).",
+    )
+
+
+@register_section("webui")
+class WebuiSection(SchemaBase):
+    __label__ = "Dashboard Web"
+    __icon__ = "🌐"
+
+    enabled: bool = enabled_field()
+    host: str = ui(
+        "Hôte", "string", default="0.0.0.0", description="Adresse de liaison du serveur web."
+    )
+    port: int = ui("Port", "number", default=8080)
+    baseUrl: str = ui(
+        "URL de base",
+        "url",
+        required=True,
+        description="URL publique du dashboard (ex: http://monserveur:8080).",
+    )
+    clientId: str = ui("Client ID Discord", "string", required=True)
+    clientSecret: str = secret_field("Client Secret Discord", required=True)
+    developerUserIds: list[str] = ui(
+        "Developer User IDs",
+        "list",
+        required=False,
+        description="IDs Discord autorisés à accéder aux pages Extensions et Logs (réservées au développeur).",
+    )


### PR DESCRIPTION
## Summary

Completes the last open bullet of Phase 5 in #15: **replace `src/webui/schemas.py` (985 LOC of hand-maintained form metadata) with Pydantic-generated schemas** living alongside each owning module.

- `src/webui/schemas.py` shrank **985 → 418 LOC** and now owns only the DSL (`SchemaBase`, `ui()`, `enabled_field()`, `hidden_message_id()`, `secret_field()`, `register_module`/`register_section`), all global config sections, and the `discord2name` per-server mapping.
- Each per-server module config moved to its owning module:
  - `features/<name>/__init__.py` — birthday, feur, secretsanta, uptime
  - `extensions/<name>/_common.py` — twitch, spotify, confrerie, zevent
  - top of `extensions/<name>.py` — coloc, compareai (IA), olympics, satisfactory, minecraft, utils, welcome, xp, youtube, tricount, speedons, streamlabs, embedmanager, vlrgg
- No new `config.py` files — configs land in files that already existed.

## Design

Fields attach UI metadata via `Field(json_schema_extra={"ui": ...})` through the `ui()` helper; class vars (`__label__`, `__icon__`, `__category__`, `__no_toggle__`, `__direct_value__`) carry module/section metadata.

Each config self-registers on import via `@register_module("moduleXyz")` / `@register_section("discord")`. `MODULE_SCHEMAS` / `GLOBAL_CONFIG_SCHEMAS` are exposed via PEP 562 module `__getattr__` so extensions can import the DSL without a circular import: schemas.py never imports extensions back.

## Verification

- **Byte-identical JSON output** against a pre-refactor snapshot (sorted-keys diff clean for both `MODULE_SCHEMAS` and `GLOBAL_CONFIG_SCHEMAS`).
- `ruff check` + `ruff format` clean on all 23 edited files.
- 23 modules + 14 sections registered (same counts as before).

## Test plan

- [ ] Pre-commit hooks pass (ruff / detect-secrets / …)
- [ ] Bot boots and the Web UI `/api/schemas/modules` + `/api/schemas/global` endpoints return the same payload as before
- [ ] Edit a module through the dashboard and confirm round-trip (load → edit → save → reload) still works

Closes the third bullet of Phase 5 in #15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)