### PR TITLE
fix: enforce singleton aiohttp session and atomic config saves

### DIFF
--- a/extensions/spotify/_common.py
+++ b/extensions/spotify/_common.py
@@ -13,12 +13,12 @@ from enum import Enum
 from typing import Any
 
 import interactions
-from src.core.http import http_client
 from interactions import Message
 
 from src.core import logging as logutil
 from src.core.config import load_config, load_discord2name
 from src.core.db import mongo_manager
+from src.core.http import http_client
 from src.discord_ext.embeds import Colors
 from src.integrations.spotify import spotify_auth
 from src.webui.schemas import (

--- a/extensions/spotify/_common.py
+++ b/extensions/spotify/_common.py
@@ -12,8 +12,8 @@ from datetime import datetime
 from enum import Enum
 from typing import Any
 
-import aiohttp
 import interactions
+from src.core.http import http_client
 from interactions import Message
 
 from src.core import logging as logutil
@@ -272,7 +272,8 @@ async def embed_song(
 
     track_id = track["id"]
     embed_url = f"https://open.spotify.com/embed/track/{track_id}"
-    async with aiohttp.ClientSession() as session, session.get(embed_url) as response:
+    session = await http_client.session()
+    async with session.get(embed_url) as response:
         content = await response.text()
     preview_match = re.search(r"\"audioPreview\":{\"url\":\"(.*?)\"}", content)
 
@@ -281,7 +282,7 @@ async def embed_song(
 
     preview_file = None
     if preview_url:
-        async with aiohttp.ClientSession() as session, session.get(preview_url) as resp:
+        async with session.get(preview_url) as resp:
             if resp.status == 200:
                 audio_data = await resp.read()
                 preview_file = interactions.File(

--- a/extensions/twitch/emotes.py
+++ b/extensions/twitch/emotes.py
@@ -2,11 +2,11 @@
 
 import os
 
-import aiohttp
 from interactions import File, OrTrigger, Task, TimeTrigger
 
 from src.core import logging as logutil
 from src.core.db import mongo_manager
+from src.core.http import http_client
 from src.discord_ext.embeds import Colors
 
 from ._common import StreamerInfo
@@ -44,7 +44,8 @@ class EmotesMixin:
         file_path = os.path.join(EMOTE_CACHE_DIR, f"{streamer_id}_{emote_id}.png")
 
         try:
-            async with aiohttp.ClientSession() as session, session.get(image_url) as response:
+            session = await http_client.session()
+            async with session.get(image_url) as response:
                 if response.status == 200:
                     content = await response.read()
                     with open(file_path, "wb") as f:

--- a/extensions/uptime/monitors.py
+++ b/extensions/uptime/monitors.py
@@ -54,24 +54,24 @@ class MonitorsMixin:
                 )
                 url = f"https://{config['uptimeKuma']['uptimeKumaUrl']}/api/monitors"
                 async with session.get(url, auth=auth) as response:
-                        if response.status == 200:
-                            data = await response.json()
-                            monitors = {}
-                            if isinstance(data, list):
-                                for monitor in data:
-                                    if "name" in monitor and "id" in monitor:
-                                        monitors[monitor["name"]] = monitor["id"]
-                            elif isinstance(data, dict):
-                                for monitor_id, monitor_data in data.items():
-                                    if isinstance(monitor_data, dict) and "name" in monitor_data:
-                                        monitors[monitor_data["name"]] = (
-                                            int(monitor_id) if monitor_id.isdigit() else monitor_id
-                                        )
-                            return monitors
-                        else:
-                            logger.warning(
-                                f"Erreur API REST pour récupération des moniteurs: {response.status}"
-                            )
+                    if response.status == 200:
+                        data = await response.json()
+                        monitors = {}
+                        if isinstance(data, list):
+                            for monitor in data:
+                                if "name" in monitor and "id" in monitor:
+                                    monitors[monitor["name"]] = monitor["id"]
+                        elif isinstance(data, dict):
+                            for monitor_id, monitor_data in data.items():
+                                if isinstance(monitor_data, dict) and "name" in monitor_data:
+                                    monitors[monitor_data["name"]] = (
+                                        int(monitor_id) if monitor_id.isdigit() else monitor_id
+                                    )
+                        return monitors
+                    else:
+                        logger.warning(
+                            f"Erreur API REST pour récupération des moniteurs: {response.status}"
+                        )
 
         except Exception as error:
             logger.error(f"Erreur lors de la récupération des moniteurs: {error}")
@@ -106,15 +106,13 @@ class MonitorsMixin:
             )
             url = f"https://{config['uptimeKuma']['uptimeKumaUrl']}/api/monitor/{sensor_id}"
             async with session.get(url, auth=auth) as response:
-                    if response.status == 200:
-                        data = await response.json()
-                        self.monitors_cache[sensor_id_str] = data
-                        return data
-                    else:
-                        logger.warning(
-                            f"Erreur API REST pour capteur {sensor_id}: {response.status}"
-                        )
-                        return None
+                if response.status == 200:
+                    data = await response.json()
+                    self.monitors_cache[sensor_id_str] = data
+                    return data
+                else:
+                    logger.warning(f"Erreur API REST pour capteur {sensor_id}: {response.status}")
+                    return None
         except Exception as error:
             logger.error(
                 f"Erreur lors de la récupération du capteur {sensor_id} via API REST: {error}"

--- a/extensions/uptime/monitors.py
+++ b/extensions/uptime/monitors.py
@@ -7,6 +7,7 @@ import aiohttp
 from interactions import AutocompleteContext
 
 from src.core import logging as logutil
+from src.core.http import http_client
 
 from ._common import config
 
@@ -46,14 +47,13 @@ class MonitorsMixin:
                 and config.get("uptimeKuma", {}).get("uptimeKumaUsername")
                 and config.get("uptimeKuma", {}).get("uptimeKumaPassword")
             ):
-                async with aiohttp.ClientSession() as session:
-                    auth = aiohttp.BasicAuth(
-                        config.get("uptimeKuma", {}).get("uptimeKumaUsername", ""),
-                        config.get("uptimeKuma", {}).get("uptimeKumaPassword", ""),
-                    )
-                    url = f"https://{config['uptimeKuma']['uptimeKumaUrl']}/api/monitors"
-
-                    async with session.get(url, auth=auth) as response:
+                session = await http_client.session()
+                auth = aiohttp.BasicAuth(
+                    config.get("uptimeKuma", {}).get("uptimeKumaUsername", ""),
+                    config.get("uptimeKuma", {}).get("uptimeKumaPassword", ""),
+                )
+                url = f"https://{config['uptimeKuma']['uptimeKumaUrl']}/api/monitors"
+                async with session.get(url, auth=auth) as response:
                         if response.status == 200:
                             data = await response.json()
                             monitors = {}
@@ -99,14 +99,13 @@ class MonitorsMixin:
                 )
 
         try:
-            async with aiohttp.ClientSession() as session:
-                auth = aiohttp.BasicAuth(
-                    config.get("uptimeKuma", {}).get("uptimeKumaUsername", ""),
-                    config.get("uptimeKuma", {}).get("uptimeKumaPassword", ""),
-                )
-                url = f"https://{config['uptimeKuma']['uptimeKumaUrl']}/api/monitor/{sensor_id}"
-
-                async with session.get(url, auth=auth) as response:
+            session = await http_client.session()
+            auth = aiohttp.BasicAuth(
+                config.get("uptimeKuma", {}).get("uptimeKumaUsername", ""),
+                config.get("uptimeKuma", {}).get("uptimeKumaPassword", ""),
+            )
+            url = f"https://{config['uptimeKuma']['uptimeKumaUrl']}/api/monitor/{sensor_id}"
+            async with session.get(url, auth=auth) as response:
                     if response.status == 200:
                         data = await response.json()
                         self.monitors_cache[sensor_id_str] = data

--- a/extensions/uptime/tasks.py
+++ b/extensions/uptime/tasks.py
@@ -6,6 +6,7 @@ import aiohttp
 from interactions import IntervalTrigger, Task
 
 from src.core import logging as logutil
+from src.core.http import http_client
 
 from ._common import config, has_kuma_credentials
 
@@ -73,11 +74,10 @@ class TasksMixin:
     @Task.create(IntervalTrigger(seconds=55))
     async def send_status_update(self):
         """Push a heartbeat to the configured Uptime Kuma push endpoint."""
-        async with aiohttp.ClientSession() as session:
-            try:
-                url = f"https://{config['uptimeKuma']['uptimeKumaUrl']}/api/push/{config['uptimeKuma']['uptimeKumaToken']}?status=up&msg=OK&ping={round(self.bot.latency * 1000, 1)}"
-
-                async with session.get(url) as response:
-                    response.raise_for_status()
-            except aiohttp.ClientError as error:
-                logger.error("Error sending status update: %s", error)
+        try:
+            url = f"https://{config['uptimeKuma']['uptimeKumaUrl']}/api/push/{config['uptimeKuma']['uptimeKumaToken']}?status=up&msg=OK&ping={round(self.bot.latency * 1000, 1)}"
+            session = await http_client.session()
+            async with session.get(url) as response:
+                response.raise_for_status()
+        except aiohttp.ClientError as error:
+            logger.error("Error sending status update: %s", error)

--- a/features/coloc/api_client.py
+++ b/features/coloc/api_client.py
@@ -5,10 +5,11 @@ import io
 import os
 from typing import Any
 
-from aiohttp import ClientError, ClientSession, ClientTimeout
+from aiohttp import ClientError, ClientSession
 from interactions import File
 
 from src.core import logging as logutil
+from src.core.http import http_client
 
 from .constants import (
     ZUNIVERS_CALENDAR_URL_TEMPLATE,
@@ -33,25 +34,14 @@ class ZuniversAPIError(Exception):
 class ZuniversAPIClient:
     """Client for interacting with the Zunivers API."""
 
-    DEFAULT_TIMEOUT = ClientTimeout(total=30)
     MAX_RETRIES = 3
     RETRY_DELAY = 1.0  # seconds
 
-    def __init__(self, session: ClientSession | None = None):
-        self._session = session
-        self._owns_session = session is None
-
     async def _get_session(self) -> ClientSession:
-        """Get or create an aiohttp session."""
-        if self._session is None or self._session.closed:
-            self._session = ClientSession(timeout=self.DEFAULT_TIMEOUT)
-            self._owns_session = True
-        return self._session
+        return await http_client.session()
 
     async def close(self) -> None:
-        """Close the session if we own it."""
-        if self._owns_session and self._session and not self._session.closed:
-            await self._session.close()
+        pass
 
     async def _request(
         self,

--- a/src/webui/context.py
+++ b/src/webui/context.py
@@ -12,7 +12,6 @@ focused modules (``routes/`` and ``sse/``) instead of one 1 000-line file.
 from __future__ import annotations
 
 import asyncio
-import json
 import os
 from dataclasses import dataclass
 from typing import Any
@@ -22,7 +21,6 @@ from fastapi import HTTPException, Request
 from src.webui.auth import DiscordOAuth, Session
 
 COOKIE_NAME = "michel_session"
-CONFIG_PATH = os.path.join("config", "config.json")
 
 
 @dataclass
@@ -42,10 +40,10 @@ class WebUIContext:
         return load_full_config() or {"config": {}, "servers": {}}
 
     def save_config(self, data: dict) -> None:
-        """Write the full config to ``config/config.json`` (non-atomic)."""
-        os.makedirs("config", exist_ok=True)
-        with open(CONFIG_PATH, "w", encoding="utf-8") as f:
-            json.dump(data, f, indent=4, ensure_ascii=False)
+        """Persist *data* atomically and notify ConfigStore subscribers."""
+        from src.core.config import config_store
+
+        config_store.save_full(data)
 
     # --- Session / authorization -------------------------------------
 


### PR DESCRIPTION
## Summary

- **ConfigStore bypass fixed**: `WebUIContext.save_config()` now calls `config_store.save_full()` instead of a plain `open()` write, giving atomic disk writes (tempfile + fsync + `os.replace`) and notifying all subscribers on every save.
- **aiohttp singleton enforced**: 5 files that were creating `aiohttp.ClientSession()` per-call now use the shared `http_client` singleton from `src.core.http`, reusing TCP connections and DNS/TLS handshakes.
- **`ZuniversAPIClient` simplified**: removed duplicated session management; `_get_session()` delegates to `http_client.session()`.
- **Unused imports removed**: `aiohttp` dropped from `twitch/emotes.py` and `spotify/_common.py`.
- **`auth.py` left unchanged**: it runs inside uvicorn's separate thread/event loop and cannot safely share the bot's asyncio-bound singleton.

## Files changed

| File | Change |
|---|---|
| `src/webui/context.py` | `save_config()` → `config_store.save_full()` |
| `extensions/uptime/tasks.py` | singleton session for heartbeat |
| `extensions/uptime/monitors.py` | singleton session for REST fallback (×2) |
| `extensions/twitch/emotes.py` | singleton session for emote download |
| `extensions/spotify/_common.py` | singleton session for embed/preview fetch (×2) |
| `features/coloc/api_client.py` | remove custom session; delegate to `http_client` |

## Test plan

- [ ] WebUI config save triggers a ConfigStore notification (check subscriber callbacks fire)
- [ ] Bot logs show a single "Shared aiohttp ClientSession created" line at startup
- [ ] Uptime heartbeat (`send_status_update`) still pushes successfully every 55s
- [ ] Uptime REST fallback (`_get_all_monitors`, `_get_sensor_info`) still resolves monitors
- [ ] Twitch emote cache download still produces files in `data/emote_cache/`
- [ ] Spotify preview fetch still attaches `preview.mp3` to embeds
- [ ] ZUniversAPIClient requests (events, loot, calendar) still succeed

https://claude.ai/code/session_01JhH2uvGFe3JvMozGG2m5iZ