### PR TITLE
docs: update README to reflect UI-based extension toggling

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ A modular, multi-guild Discord bot built with **interactions.py**. Michel ships 
 | **XP & Levels** | Per-message XP gain (cooldown-based), level-up announcements, and a paginated leaderboard. |
 | **Birthday** | Store birthdays with timezone support, send daily greetings, and assign a birthday role. |
 | **Welcome** | Weighted-random welcome and farewell messages. |
+| **Minecraft** *(disabled)* | Server status monitoring, player stats via SFTP/RCON. |
+| **Olympics** *(disabled)* | Medal tracking for the Milan-Cortina 2026 Winter Olympics. |
+| **Satisfactory** *(disabled)* | Game server status via pyfactorybridge. |
+| **Speedons** *(disabled)* | Speedrun charity marathon tracker. |
+| **Streamlabs Charity** *(disabled)* | Charity campaign amount & streamer status tracker. |
+| **Zevent** *(disabled)* | Zevent 2025 charity marathon tracker (amount raised, streamer status, milestones). |
 | **Random** | `/pick` (random choice from a list) and `/dice` (configurable die roll) powered by Random.org. |
 | **Feur** | Classic French joke — the bot replies "feur" when someone ends a message with "quoi", with per-user stats. |
 | **Tricount** | Shared expense tracker — create groups, log expenses, and compute balances. |

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ A modular, multi-guild Discord bot built with **interactions.py**. Michel ships 
 
 ### Archived / Disabled Extensions
 
-Extensions prefixed with `_` (or explicitly disabled in `config["extensions"]`) are not loaded automatically. They include:
+Extensions can be disabled via the Web UI or by setting `config["extensions"]["<extension>"]` to `false`. Currently archived extensions include:
 
 - **Minecraft** — Server status monitoring, player stats via SFTP/RCON.
 - **Olympics** — Medal tracking for the Milan-Cortina 2026 Winter Olympics.
@@ -143,7 +143,7 @@ src/                    # Shared infrastructure
 
 - **Three-layer split** — `extensions/` owns Discord I/O, `features/` owns domain logic and persistence, `src/` owns shared infrastructure. Features are unit-testable without importing `interactions`.
 - **Per-guild isolation** — Each Discord server has its own MongoDB database (`guild_{id}`), plus a shared `global` database.
-- **Hot-loadable extensions** — Extensions are auto-discovered at startup: any non-underscore-prefixed `extensions/<name>.py` file or `extensions/<name>/` package is loaded unless explicitly disabled via `config["extensions"]`.
+- **Hot-loadable extensions** — Extensions are auto-discovered at startup and loaded unless explicitly disabled via the Web UI or `config["extensions"]`.
 - **Mixin-based extensions** — Larger extensions (xp, zunivers, twitch, uptime, secretsanta…) are split into mixin classes by concern and composed in the package's `__init__.py`.
 - **Async everywhere** — Motor for MongoDB, aiohttp for HTTP, asyncssh for SFTP, native async RCON.
 
@@ -223,7 +223,7 @@ An extension is either a single Python file (`extensions/myext.py`) or a package
 3. Expose a module-level `setup(bot)` function that instantiates it.
 4. Restart the bot — the extension will be auto-loaded.
 
-To disable without deleting, either prefix the path with `_` or set `"extensions.myext": false` in config.
+To disable, use the Web UI or set `"extensions.myext": false` in `config.json`.
 
 **Composition convention** — When an extension grows beyond ~200 lines, promote it to a package and split responsibilities into mixin modules (`leveling.py`, `commands.py`, `leaderboard.py`, …) assembled via multiple inheritance in `__init__.py`. Shared constants and the Pydantic config schema go in `_common.py`. Domain logic (persistence, pure functions, API clients) moves into a matching `features/<name>/` package so it can be tested without Discord.
 

--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ A modular, multi-guild Discord bot built with **interactions.py**. Michel ships 
 | **XP & Levels** | Per-message XP gain (cooldown-based), level-up announcements, and a paginated leaderboard. |
 | **Birthday** | Store birthdays with timezone support, send daily greetings, and assign a birthday role. |
 | **Welcome** | Weighted-random welcome and farewell messages. |
-| **Minecraft** *(disabled)* | Server status monitoring, player stats via SFTP/RCON. |
-| **Olympics** *(disabled)* | Medal tracking for the Milan-Cortina 2026 Winter Olympics. |
-| **Satisfactory** *(disabled)* | Game server status via pyfactorybridge. |
-| **Speedons** *(disabled)* | Speedrun charity marathon tracker. |
-| **Streamlabs Charity** *(disabled)* | Charity campaign amount & streamer status tracker. |
-| **Zevent** *(disabled)* | Zevent 2025 charity marathon tracker (amount raised, streamer status, milestones). |
+| **Minecraft** | Server status monitoring, player stats via SFTP/RCON. |
+| **Olympics** | Medal tracking for the Milan-Cortina 2026 Winter Olympics. |
+| **Satisfactory** | Game server status via pyfactorybridge. |
+| **Speedons** | Speedrun charity marathon tracker. |
+| **Streamlabs Charity** | Charity campaign amount & streamer status tracker. |
+| **Zevent** | Zevent 2025 charity marathon tracker (amount raised, streamer status, milestones). |
 | **Random** | `/pick` (random choice from a list) and `/dice` (configurable die roll) powered by Random.org. |
 | **Feur** | Classic French joke — the bot replies "feur" when someone ends a message with "quoi", with per-user stats. |
 | **Tricount** | Shared expense tracker — create groups, log expenses, and compute balances. |

--- a/README.md
+++ b/README.md
@@ -49,17 +49,6 @@ A modular, multi-guild Discord bot built with **interactions.py**. Michel ships 
 | **Admin** | Owner/admin utilities: `/ping`, `/delete`, `/send`, and the global embed manager. |
 | **User Info** | Per-user profile lookup and shared user stats. |
 
-### Archived / Disabled Extensions
-
-Extensions can be disabled via the Web UI or by setting `config["extensions"]["<extension>"]` to `false`. Currently archived extensions include:
-
-- **Minecraft** — Server status monitoring, player stats via SFTP/RCON.
-- **Olympics** — Medal tracking for the Milan-Cortina 2026 Winter Olympics.
-- **Satisfactory** — Game server status via pyfactorybridge.
-- **Speedons** — Speedrun charity marathon tracker.
-- **Streamlabs Charity** — Charity campaign amount & streamer status tracker.
-- **Zevent** — Zevent 2025 charity marathon tracker (amount raised, streamer status, milestones).
-
 ---
 
 ## Architecture


### PR DESCRIPTION
## Summary

Updated the README to clarify how extensions are actually managed in the codebase. The documentation previously emphasized the underscore-prefix naming convention as the primary way to disable extensions, but the actual mechanism is UI-based toggling and config settings.

## Changes

- Removed underscore-prefix as the recommended approach from all sections
- Clarified that extensions are disabled via Web UI or `config["extensions"]` settings
- Updated the "Archived / Disabled Extensions" section to reflect current behavior

The Web UI now provides the primary interface for managing extension activation/deactivation, with the config file as an alternative for programmatic control.