### PR TITLE
fix(twitch): recreate scheduled event when stale reference 404s

### DIFF
--- a/extensions/twitch/schedule.py
+++ b/extensions/twitch/schedule.py
@@ -1,5 +1,6 @@
 """Twitch schedule embed + planning message + Discord scheduled-event sync."""
 
+import contextlib
 import os
 from datetime import datetime, timedelta
 
@@ -186,10 +187,8 @@ class ScheduleMixin:
                             )
                             await streamer.scheduled_event.edit(status=ScheduledEventStatus.ACTIVE)
                     elif streamer.scheduled_event:
-                        try:
+                        with contextlib.suppress(NotFound):
                             await streamer.scheduled_event.delete()
-                        except NotFound:
-                            pass
                         streamer.scheduled_event = None
                 except Exception as e:
                     logger.error(f"Error handling scheduled event for {streamer.streamer_id}: {e}")

--- a/extensions/twitch/schedule.py
+++ b/extensions/twitch/schedule.py
@@ -16,6 +16,7 @@ from interactions import (
     TimeTrigger,
     utils,
 )
+from interactions.client.errors import NotFound
 from twitchAPI.object.api import ChannelStreamSchedule, ChannelStreamScheduleSegment
 from twitchAPI.object.eventsub import ChannelUpdateEvent, StreamOfflineEvent
 from twitchAPI.type import TwitchResourceNotFound
@@ -161,12 +162,20 @@ class ScheduleMixin:
 
                     if streamer.manage_discord_events:
                         if streamer.scheduled_event:
-                            await streamer.scheduled_event.edit(
-                                name=title100,
-                                description=f"**{title}**\n\n{description}",
-                                end_time=datetime.now(self.timezone) + timedelta(days=1),
-                            )
-                        else:
+                            try:
+                                await streamer.scheduled_event.edit(
+                                    name=title100,
+                                    description=f"**{title}**\n\n{description}",
+                                    end_time=datetime.now(self.timezone) + timedelta(days=1),
+                                )
+                            except NotFound:
+                                # Event was deleted in Discord; drop the stale reference
+                                # so we recreate it below.
+                                logger.warning(
+                                    f"Scheduled event for {streamer.streamer_id} no longer exists, recreating"
+                                )
+                                streamer.scheduled_event = None
+                        if not streamer.scheduled_event:
                             streamer.scheduled_event = await guild.create_scheduled_event(
                                 name=title100,
                                 event_type=ScheduledEventType.EXTERNAL,
@@ -177,7 +186,10 @@ class ScheduleMixin:
                             )
                             await streamer.scheduled_event.edit(status=ScheduledEventStatus.ACTIVE)
                     elif streamer.scheduled_event:
-                        await streamer.scheduled_event.delete()
+                        try:
+                            await streamer.scheduled_event.delete()
+                        except NotFound:
+                            pass
                         streamer.scheduled_event = None
                 except Exception as e:
                     logger.error(f"Error handling scheduled event for {streamer.streamer_id}: {e}")
@@ -197,9 +209,11 @@ class ScheduleMixin:
             if streamer.scheduled_event:
                 try:
                     await streamer.scheduled_event.delete()
-                    streamer.scheduled_event = None
+                except NotFound:
+                    pass
                 except Exception as e:
                     logger.error(f"Error deleting scheduled event for {streamer.streamer_id}: {e}")
+                streamer.scheduled_event = None
 
             if has_message:
                 try:


### PR DESCRIPTION
## Summary

Fixes the `PATCH .../scheduled-events/...: 404 Unknown Guild Scheduled Event` error and the symptom that the bot stops creating events for a streamer.

`StreamerInfo.scheduled_event` is an in-memory reference to a Discord scheduled-event object. If the event is deleted out-of-band (manually, by a moderator, or by Discord), the reference goes stale and every subsequent `edit_message()` call PATCHes a non-existent event:

- `extensions/twitch/schedule.py:164` — `await streamer.scheduled_event.edit(...)` raises `HTTPException 404`
- The broad `except Exception` at line 183 only logs the failure; it never clears the stale reference, so the `else` branch that creates a new event is never reached.

This change:

1. Catches `NotFound` (Discord 404) specifically around `.edit()` on the stored event, clears `streamer.scheduled_event`, and falls through to the create-new-event branch on the same call.
2. Catches `NotFound` around `.delete()` in both the "manage_discord_events disabled" branch and the offline path, clearing the reference unconditionally so we don't get stuck.

## Test plan

- [ ] Trigger an `on_live_start` after deleting the scheduled event in Discord — bot should log a warning and create a fresh event instead of looping on 404.
- [ ] Normal live start with no existing event — event is created as before.
- [ ] Normal `on_update` while live with an existing event — event is edited as before.
- [ ] `on_live_end` after the scheduled event was already deleted in Discord — no error, reference cleared.

https://claude.ai/code/session_01KxGfZQfz7omoU667FHVtxL

---
_Generated by [Claude Code](https://claude.ai/code/session_01KxGfZQfz7omoU667FHVtxL)_