### PR TITLE
fix(vlrgg): corriger les fuseaux horaires des dates de matchs

### DIFF
--- a/features/vlrgg/client.py
+++ b/features/vlrgg/client.py
@@ -15,8 +15,9 @@ Note: Un cache avec TTL court est utilisé (API self-hosted sur vlr.drndvs.fr).
 import asyncio
 import re
 import time
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime
 from typing import Any
+from zoneinfo import ZoneInfo
 
 from src.core import logging as logutil
 from src.core.http import fetch
@@ -120,18 +121,22 @@ def filter_team_matches(team: str, matches: list[dict]) -> list[dict]:
 
 
 def parse_vlrgg_timestamp(timestamp_str: str) -> datetime | None:
-    """Parse un timestamp VLR.gg en datetime.
+    """Parse un timestamp VLR.gg en datetime aware (UTC).
+
+    L'API VLR.gg renvoie ce champ en UTC malgré le format sans suffixe ; on
+    attache donc explicitement le fuseau pour éviter une conversion implicite
+    en heure locale lors de l'appel ultérieur à ``dt.timestamp()``.
 
     Args:
         timestamp_str: Chaîne de timestamp (ex: "2024-04-24 21:00:00").
 
     Returns:
-        datetime correspondant, ou None si le parsing échoue.
+        datetime aware (UTC) correspondant, ou None si le parsing échoue.
     """
     if not timestamp_str:
         return None
     try:
-        return datetime.strptime(timestamp_str, "%Y-%m-%d %H:%M:%S")
+        return datetime.strptime(timestamp_str, "%Y-%m-%d %H:%M:%S").replace(tzinfo=UTC)
     except (ValueError, TypeError):
         return None
 
@@ -213,8 +218,10 @@ def expand_round_name(round_str: str) -> str:
     return round_str
 
 
-# L'API VLR.gg renvoie les heures en EST (UTC-5)
-_VLR_TIMEZONE = timezone(timedelta(hours=-5))
+# L'API VLR.gg (vlr.drndvs.fr) restitue les dates de /team/matches dans
+# l'heure locale de son serveur (Europe/Paris) — ex: "8:00 pm" correspond
+# à 20h CEST/CET. ZoneInfo gère le passage à l'heure d'été automatiquement.
+_VLR_TIMEZONE = ZoneInfo("Europe/Paris")
 
 # Formats de date courants retournés par l'API VLR.gg
 _DATE_FORMATS = [
@@ -230,7 +237,8 @@ _DATE_FORMATS = [
 def format_vlr_date(date_str: str) -> str:
     """Formate une date VLR.gg en timestamp Discord (affichage local pour chaque utilisateur).
 
-    Les dates de l'API VLR.gg sont en EST (UTC-5).
+    Les dates de /team/matches sont rendues dans l'heure locale du serveur
+    de l'API (Europe/Paris) ; ZoneInfo gère CET/CEST automatiquement.
     Retourne un timestamp Discord <t:UNIX:f> si le parsing réussit,
     sinon retourne la chaîne telle quelle.
     """
@@ -242,7 +250,6 @@ def format_vlr_date(date_str: str) -> str:
     for fmt in _DATE_FORMATS:
         try:
             dt = datetime.strptime(cleaned, fmt)
-            # Attacher le fuseau EST pour un timestamp Unix correct
             dt = dt.replace(tzinfo=_VLR_TIMEZONE)
             return format_discord_timestamp(dt, "f")
         except ValueError:


### PR DESCRIPTION
## Summary

Deux bugs distincts faisaient que les heures affichées dans les embeds VLR.gg étaient décalées.

### 1. `parse_vlrgg_timestamp` (matchs à venir / `unix_timestamp`)
Le champ `unix_timestamp` retourné par `/v2/match?q=upcoming` est en **UTC** (vérifié : l'API a renvoyé `2026-04-25 13:00:00` avec `time_until_match: "6m from now"` alors qu'il était 12:55 UTC). La fonction renvoyait un `datetime` naïf, donc l'appel suivant à `dt.timestamp()` l'interprétait comme l'heure locale du bot (CEST = UTC+2 en été), décalant les "prochains matchs" de **1–2 heures**.

### 2. `_VLR_TIMEZONE` (matchs passés / `date` de `/team/matches`)
La constante était codée en dur à `UTC-5` (EST), ce qui était faux à deux titres :
- L'API `vlr.drndvs.fr` rend les dates dans son fuseau serveur **Europe/Paris** (vérifié : `/match/details` renvoie explicitement `"...8:00 PM CEST"`).
- Un offset fixe ne gère pas le passage CET ↔ CEST, ce qui ajouterait une autre heure de décalage deux fois par an.

Pour un match `"2026/04/23 8:00 pm"` (CEST = 18:00 UTC), le code l'interprétait comme 8:00 PM EST = 01:00 UTC le lendemain — soit **7 heures de décalage**.

### Correctifs
- `parse_vlrgg_timestamp` attache désormais `UTC` au datetime parsé.
- `_VLR_TIMEZONE` passe à `ZoneInfo("Europe/Paris")` (DST géré automatiquement).

## Test plan
- [x] `parse_vlrgg_timestamp("2026-04-25 13:00:00")` produit un Unix timestamp identique à celui de `datetime(2026,4,25,13,tzinfo=UTC)`.
- [x] `format_vlr_date("2026/04/238:00 pm")` (CEST) → `<t:1776967200:f>` = 18:00 UTC.
- [x] `format_vlr_date("2026/01/158:00 pm")` (CET, hors DST) → 19:00 UTC.
- [x] `ruff check` et `ruff format --check` passent.
- [ ] Vérifier dans Discord que les embeds "Prochains matchs" et "Derniers matchs" affichent l'heure correcte sur un suivi d'équipe en production.

https://claude.ai/code/session_01LLYbNNRatoiye9LCbPjZ6n

---
_Generated by [Claude Code](https://claude.ai/code/session_01LLYbNNRatoiye9LCbPjZ6n)_