### PR TITLE
feat(extensions): rolemenu, starboard, suggestions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,9 @@ Pipfile.lock
 # poetry
 poetry.lock
 
+# uv
+uv.lock
+
 # celery beat schedule file
 celerybeat-schedule
 celerybeat.pid

--- a/extensions/reactionroles/__init__.py
+++ b/extensions/reactionroles/__init__.py
@@ -1,0 +1,46 @@
+"""Reaction Roles Discord extension — self-assignable roles via persistent buttons.
+
+Slash commands (admin-only):
+- ``/rolemenu create`` — create a menu in a channel with up to 25 (role, emoji, label) entries
+- ``/rolemenu list`` — list role menus on this server
+- ``/rolemenu delete`` — remove a menu (deletes the message + Mongo doc)
+- ``/rolemenu edit`` — change title/description of an existing menu
+
+Buttons are persistent: their callbacks rebind on extension load, so menus
+keep working across restarts. Per-guild config: ``moduleReactionRoles``.
+"""
+
+from interactions import Client, Extension, listen
+
+from features.reactionroles import ReactionRolesRepository
+
+from ._common import enabled_servers, logger
+from .buttons import ButtonsMixin
+from .commands import CommandsMixin
+
+
+class ReactionRolesExtension(Extension, CommandsMixin, ButtonsMixin):
+    def __init__(self, bot: Client):
+        self.bot = bot
+        self._repos: dict[str, ReactionRolesRepository] = {}
+
+    def repository(self, guild_id: str | int) -> ReactionRolesRepository:
+        gid = str(guild_id)
+        repo = self._repos.get(gid)
+        if repo is None:
+            repo = ReactionRolesRepository(gid)
+            self._repos[gid] = repo
+        return repo
+
+    @listen()
+    async def on_startup(self):
+        for gid in enabled_servers:
+            await self.repository(gid).ensure_indexes()
+        logger.info("Reaction Roles ready (%d guild(s))", len(enabled_servers))
+
+
+def setup(bot: Client) -> None:
+    ReactionRolesExtension(bot)
+
+
+__all__ = ["ReactionRolesExtension", "setup"]

--- a/extensions/reactionroles/_common.py
+++ b/extensions/reactionroles/_common.py
@@ -1,17 +1,15 @@
-"""Config schema, logger, shared constants, and embed/component builders.
+"""Config schema, logger, and shared constants.
 
-The builders are kept here (not in ``commands.py``) so the WebUI builder can
-reuse the exact same Discord rendering as ``/rolemenu create``.
+Embed/component builders live in :mod:`features.reactionroles.builders` so
+the WebUI route can reuse them without crossing the ``extensions/`` package
+boundary.
 """
 
 import os
 
-from interactions import ActionRow, Button, ButtonStyle, Embed
-
-from features.reactionroles import RoleMenuEntry
+from features.reactionroles import BUTTON_PREFIX, MAX_ENTRIES, build_components, build_embed
 from src.core import logging as logutil
 from src.core.config import load_config
-from src.discord_ext.embeds import Colors
 from src.webui.schemas import SchemaBase, enabled_field, register_module
 
 logger = logutil.init_logger(os.path.basename(__file__))
@@ -28,35 +26,15 @@ class ReactionRolesConfig(SchemaBase):
 
 
 _, _, enabled_servers = load_config("moduleReactionRoles")
-enabled_servers_int = [int(s) for s in enabled_servers]  # type: ignore[misc]
+enabled_servers_int = [int(s) for s in enabled_servers]
 
-# Namespace for persistent button custom_ids: rrole:{menu_id}:{entry_idx}
-BUTTON_PREFIX = "rrole"
-# Discord caps action rows at 5 buttons each, max 5 rows per message.
-MAX_ENTRIES = 25
-
-
-def build_embed(title: str, description: str | None, entries: list[RoleMenuEntry]) -> Embed:
-    """Render a role-menu embed (title, optional description, role/emoji/label list)."""
-    body_lines = [f"{e.emoji} <@&{e.role_id}> — {e.label}" for e in entries]
-    embed_description = (description + "\n\n" if description else "") + "\n".join(body_lines)
-    return Embed(title=title, description=embed_description, color=Colors.UTIL)
-
-
-def build_components(menu_id: str, entries: list[RoleMenuEntry]) -> list[ActionRow]:
-    """Render the action rows of buttons whose ``custom_id`` toggles each role."""
-    rows: list[ActionRow] = []
-    for chunk_start in range(0, len(entries), 5):
-        buttons = []
-        for offset, entry in enumerate(entries[chunk_start : chunk_start + 5]):
-            idx = chunk_start + offset
-            buttons.append(
-                Button(
-                    label=entry.label[:80],
-                    style=ButtonStyle.SECONDARY,
-                    emoji=entry.emoji,
-                    custom_id=f"{BUTTON_PREFIX}:{menu_id}:{idx}",
-                )
-            )
-        rows.append(ActionRow(*buttons))
-    return rows
+__all__ = [
+    "BUTTON_PREFIX",
+    "MAX_ENTRIES",
+    "ReactionRolesConfig",
+    "build_components",
+    "build_embed",
+    "enabled_servers",
+    "enabled_servers_int",
+    "logger",
+]

--- a/extensions/reactionroles/_common.py
+++ b/extensions/reactionroles/_common.py
@@ -1,9 +1,17 @@
-"""Config schema, logger, and shared constants for the reaction-roles extension."""
+"""Config schema, logger, shared constants, and embed/component builders.
+
+The builders are kept here (not in ``commands.py``) so the WebUI builder can
+reuse the exact same Discord rendering as ``/rolemenu create``.
+"""
 
 import os
 
+from interactions import ActionRow, Button, ButtonStyle, Embed
+
+from features.reactionroles import RoleMenuEntry
 from src.core import logging as logutil
 from src.core.config import load_config
+from src.discord_ext.embeds import Colors
 from src.webui.schemas import SchemaBase, enabled_field, register_module
 
 logger = logutil.init_logger(os.path.basename(__file__))
@@ -26,3 +34,29 @@ enabled_servers_int = [int(s) for s in enabled_servers]  # type: ignore[misc]
 BUTTON_PREFIX = "rrole"
 # Discord caps action rows at 5 buttons each, max 5 rows per message.
 MAX_ENTRIES = 25
+
+
+def build_embed(title: str, description: str | None, entries: list[RoleMenuEntry]) -> Embed:
+    """Render a role-menu embed (title, optional description, role/emoji/label list)."""
+    body_lines = [f"{e.emoji} <@&{e.role_id}> — {e.label}" for e in entries]
+    embed_description = (description + "\n\n" if description else "") + "\n".join(body_lines)
+    return Embed(title=title, description=embed_description, color=Colors.UTIL)
+
+
+def build_components(menu_id: str, entries: list[RoleMenuEntry]) -> list[ActionRow]:
+    """Render the action rows of buttons whose ``custom_id`` toggles each role."""
+    rows: list[ActionRow] = []
+    for chunk_start in range(0, len(entries), 5):
+        buttons = []
+        for offset, entry in enumerate(entries[chunk_start : chunk_start + 5]):
+            idx = chunk_start + offset
+            buttons.append(
+                Button(
+                    label=entry.label[:80],
+                    style=ButtonStyle.SECONDARY,
+                    emoji=entry.emoji,
+                    custom_id=f"{BUTTON_PREFIX}:{menu_id}:{idx}",
+                )
+            )
+        rows.append(ActionRow(*buttons))
+    return rows

--- a/extensions/reactionroles/_common.py
+++ b/extensions/reactionroles/_common.py
@@ -1,0 +1,28 @@
+"""Config schema, logger, and shared constants for the reaction-roles extension."""
+
+import os
+
+from src.core import logging as logutil
+from src.core.config import load_config
+from src.webui.schemas import SchemaBase, enabled_field, register_module
+
+logger = logutil.init_logger(os.path.basename(__file__))
+
+
+@register_module("moduleReactionRoles")
+class ReactionRolesConfig(SchemaBase):
+    __label__ = "Rôles à boutons"
+    __description__ = "Menus de rôles auto-attribués via boutons persistants."
+    __icon__ = "🎭"
+    __category__ = "Communauté"
+
+    enabled: bool = enabled_field()
+
+
+_, _, enabled_servers = load_config("moduleReactionRoles")
+enabled_servers_int = [int(s) for s in enabled_servers]  # type: ignore[misc]
+
+# Namespace for persistent button custom_ids: rrole:{menu_id}:{entry_idx}
+BUTTON_PREFIX = "rrole"
+# Discord caps action rows at 5 buttons each, max 5 rows per message.
+MAX_ENTRIES = 25

--- a/extensions/reactionroles/buttons.py
+++ b/extensions/reactionroles/buttons.py
@@ -1,0 +1,61 @@
+"""Persistent button callback that toggles the role on click."""
+
+import re
+
+from interactions import ComponentContext, component_callback
+
+from src.discord_ext.messages import send_error
+
+from ._common import BUTTON_PREFIX, logger
+
+_CUSTOM_ID_RE = re.compile(rf"^{BUTTON_PREFIX}:([a-f0-9]{{24}}):(\d+)$")
+
+
+class ButtonsMixin:
+    """Handle clicks on role-menu buttons (toggle role on/off)."""
+
+    @component_callback(_CUSTOM_ID_RE)
+    async def on_role_button(self, ctx: ComponentContext) -> None:
+        if not ctx.guild:
+            await send_error(ctx, "Cette action n'est disponible qu'en serveur.")
+            return
+
+        match = _CUSTOM_ID_RE.match(ctx.custom_id)
+        if not match:
+            return
+        menu_id, entry_idx_str = match.group(1), match.group(2)
+        entry_idx = int(entry_idx_str)
+
+        menu = await self.repository(ctx.guild_id).get(menu_id)
+        if not menu:
+            await send_error(ctx, "Ce menu n'existe plus.")
+            return
+        if entry_idx >= len(menu.entries):
+            await send_error(ctx, "Cette entrée n'existe plus dans le menu.")
+            return
+
+        role_id = int(menu.entries[entry_idx].role_id)
+        member = ctx.author
+        try:
+            has_role = any(int(getattr(r, "id", r)) == role_id for r in member.roles)
+        except Exception:
+            has_role = False
+
+        try:
+            if has_role:
+                await member.remove_role(role_id, reason="Reaction-roles toggle")
+                await ctx.send(f"Rôle <@&{role_id}> retiré ❌", ephemeral=True)
+                logger.info(
+                    "Removed role %s from %s in guild %s", role_id, ctx.author.id, ctx.guild_id
+                )
+            else:
+                await member.add_role(role_id, reason="Reaction-roles toggle")
+                await ctx.send(f"Rôle <@&{role_id}> ajouté ✅", ephemeral=True)
+                logger.info(
+                    "Added role %s to %s in guild %s", role_id, ctx.author.id, ctx.guild_id
+                )
+        except Exception as e:
+            logger.error("Failed to toggle role %s for %s: %s", role_id, ctx.author.id, e)
+            await send_error(
+                ctx, "Impossible de modifier ce rôle (permissions ou hiérarchie ?)."
+            )

--- a/extensions/reactionroles/buttons.py
+++ b/extensions/reactionroles/buttons.py
@@ -51,11 +51,7 @@ class ButtonsMixin:
             else:
                 await member.add_role(role_id, reason="Reaction-roles toggle")
                 await ctx.send(f"Rôle <@&{role_id}> ajouté ✅", ephemeral=True)
-                logger.info(
-                    "Added role %s to %s in guild %s", role_id, ctx.author.id, ctx.guild_id
-                )
+                logger.info("Added role %s to %s in guild %s", role_id, ctx.author.id, ctx.guild_id)
         except Exception as e:
             logger.error("Failed to toggle role %s for %s: %s", role_id, ctx.author.id, e)
-            await send_error(
-                ctx, "Impossible de modifier ce rôle (permissions ou hiérarchie ?)."
-            )
+            await send_error(ctx, "Impossible de modifier ce rôle (permissions ou hiérarchie ?).")

--- a/extensions/reactionroles/commands.py
+++ b/extensions/reactionroles/commands.py
@@ -1,0 +1,295 @@
+"""Slash commands for managing role menus."""
+
+from datetime import datetime
+
+from interactions import (
+    ActionRow,
+    BaseChannel,
+    Button,
+    ButtonStyle,
+    ChannelType,
+    Embed,
+    OptionType,
+    Permissions,
+    SlashContext,
+    slash_command,
+    slash_default_member_permission,
+    slash_option,
+)
+
+from features.reactionroles import RoleMenu, RoleMenuEntry
+from src.discord_ext.embeds import Colors
+from src.discord_ext.messages import require_guild, send_error, send_success
+
+from ._common import BUTTON_PREFIX, MAX_ENTRIES, enabled_servers_int, logger
+
+
+def _parse_entries(raw: str) -> list[RoleMenuEntry] | str:
+    """Parse ``"roleId,emoji,label;roleId,emoji,label"``. Return list or error message."""
+    parts = [p.strip() for p in raw.split(";") if p.strip()]
+    if not parts:
+        return "Vous devez fournir au moins une entrée."
+    if len(parts) > MAX_ENTRIES:
+        return f"Maximum {MAX_ENTRIES} entrées par menu (Discord limite à 5×5 boutons)."
+
+    entries: list[RoleMenuEntry] = []
+    for idx, part in enumerate(parts, 1):
+        bits = [b.strip() for b in part.split(",", 2)]
+        if len(bits) != 3:
+            return f"Entrée {idx} invalide : attendu « roleId,emoji,label »."
+        role_id, emoji, label = bits
+        if not role_id.isdigit():
+            return f"Entrée {idx} : roleId doit être un identifiant numérique."
+        if not emoji:
+            return f"Entrée {idx} : emoji manquant."
+        if not label:
+            return f"Entrée {idx} : libellé manquant."
+        if len(label) > 80:
+            return f"Entrée {idx} : libellé trop long (max 80 caractères)."
+        entries.append(RoleMenuEntry(role_id=role_id, emoji=emoji, label=label))
+    return entries
+
+
+def _build_embed(title: str, description: str | None, entries: list[RoleMenuEntry]) -> Embed:
+    body_lines = [f"{e.emoji} <@&{e.role_id}> — {e.label}" for e in entries]
+    embed_description = (description + "\n\n" if description else "") + "\n".join(body_lines)
+    return Embed(title=title, description=embed_description, color=Colors.UTIL)
+
+
+def _build_components(menu_id: str, entries: list[RoleMenuEntry]) -> list[ActionRow]:
+    rows: list[ActionRow] = []
+    for chunk_start in range(0, len(entries), 5):
+        buttons = []
+        for offset, entry in enumerate(entries[chunk_start : chunk_start + 5]):
+            idx = chunk_start + offset
+            buttons.append(
+                Button(
+                    label=entry.label[:80],
+                    style=ButtonStyle.SECONDARY,
+                    emoji=entry.emoji,
+                    custom_id=f"{BUTTON_PREFIX}:{menu_id}:{idx}",
+                )
+            )
+        rows.append(ActionRow(*buttons))
+    return rows
+
+
+class CommandsMixin:
+    """Admin slash commands to create / list / edit / delete role menus."""
+
+    @slash_command(
+        name="rolemenu",
+        description="Gérer les menus de rôles",
+        sub_cmd_name="create",
+        sub_cmd_description="Créer un menu de rôles dans un salon",
+        scopes=enabled_servers_int,  # type: ignore
+    )
+    @slash_option(
+        "channel",
+        "Salon où publier le menu",
+        opt_type=OptionType.CHANNEL,
+        required=True,
+        channel_types=[ChannelType.GUILD_TEXT, ChannelType.GUILD_NEWS],
+    )
+    @slash_option(
+        "title",
+        "Titre du menu",
+        opt_type=OptionType.STRING,
+        required=True,
+    )
+    @slash_option(
+        "entries",
+        "Entrées séparées par « ; ». Format : roleId,emoji,libellé",
+        opt_type=OptionType.STRING,
+        required=True,
+    )
+    @slash_option(
+        "description",
+        "Description optionnelle affichée au-dessus des rôles",
+        opt_type=OptionType.STRING,
+        required=False,
+    )
+    @slash_default_member_permission(Permissions.ADMINISTRATOR | Permissions.MANAGE_ROLES)
+    async def rolemenu_create(
+        self,
+        ctx: SlashContext,
+        channel: BaseChannel,
+        title: str,
+        entries: str,
+        description: str | None = None,
+    ) -> None:
+        if not await require_guild(ctx):
+            return
+
+        parsed = _parse_entries(entries)
+        if isinstance(parsed, str):
+            await send_error(ctx, parsed)
+            return
+
+        # Validate role IDs against the guild before posting.
+        guild_role_ids = {str(r.id) for r in ctx.guild.roles}
+        for entry in parsed:
+            if entry.role_id not in guild_role_ids:
+                await send_error(ctx, f"Rôle introuvable : <@&{entry.role_id}> ({entry.role_id}).")
+                return
+
+        if not hasattr(channel, "send"):
+            await send_error(ctx, "Ce salon ne permet pas l'envoi de messages.")
+            return
+
+        await ctx.defer(ephemeral=True)
+
+        menu = RoleMenu(
+            guild_id=str(ctx.guild_id),
+            channel_id=str(channel.id),
+            title=title,
+            description=description,
+            entries=parsed,
+            created_by=str(ctx.author.id),
+            created_at=datetime.now(),
+        )
+        menu_id = await self.repository(ctx.guild_id).add(menu)
+
+        embed = _build_embed(title, description, parsed)
+        components = _build_components(menu_id, parsed)
+        try:
+            sent = await channel.send(embeds=[embed], components=components)  # type: ignore[union-attr]
+        except Exception as e:
+            await self.repository(ctx.guild_id).delete(menu_id)
+            await send_error(ctx, f"Échec de l'envoi du menu : {e}")
+            return
+
+        await self.repository(ctx.guild_id).update(menu_id, message_id=str(sent.id))
+        logger.info(
+            "Role menu %s created by %s in #%s with %d entries",
+            menu_id,
+            ctx.author.username,
+            getattr(channel, "name", channel.id),
+            len(parsed),
+        )
+        await send_success(ctx, f"Menu créé (id `{menu_id}`).")
+
+    @rolemenu_create.subcommand(
+        sub_cmd_name="list",
+        sub_cmd_description="Lister les menus de rôles de ce serveur",
+    )
+    @slash_default_member_permission(Permissions.ADMINISTRATOR | Permissions.MANAGE_ROLES)
+    async def rolemenu_list(self, ctx: SlashContext) -> None:
+        if not await require_guild(ctx):
+            return
+        menus = await self.repository(ctx.guild_id).list()
+        if not menus:
+            await ctx.send("Aucun menu de rôles enregistré.", ephemeral=True)
+            return
+
+        lines = []
+        for menu in menus:
+            link = (
+                f"https://discord.com/channels/{menu.guild_id}/{menu.channel_id}/{menu.message_id}"
+                if menu.message_id
+                else "—"
+            )
+            lines.append(
+                f"`{menu.id}` — **{menu.title}** ({len(menu.entries)} rôles) "
+                f"<#{menu.channel_id}> [↗]({link})"
+            )
+        embed = Embed(
+            title="Menus de rôles",
+            description="\n".join(lines),
+            color=Colors.UTIL,
+        )
+        await ctx.send(embeds=[embed], ephemeral=True)
+
+    @rolemenu_create.subcommand(
+        sub_cmd_name="delete",
+        sub_cmd_description="Supprimer un menu de rôles",
+    )
+    @slash_option(
+        "menu_id",
+        "ID du menu (visible via /rolemenu list)",
+        opt_type=OptionType.STRING,
+        required=True,
+    )
+    @slash_default_member_permission(Permissions.ADMINISTRATOR | Permissions.MANAGE_ROLES)
+    async def rolemenu_delete(self, ctx: SlashContext, menu_id: str) -> None:
+        if not await require_guild(ctx):
+            return
+        menu = await self.repository(ctx.guild_id).get(menu_id)
+        if not menu:
+            await send_error(ctx, "Menu introuvable.")
+            return
+
+        await self.repository(ctx.guild_id).delete(menu_id)
+
+        if menu.message_id:
+            try:
+                channel = await self.bot.fetch_channel(int(menu.channel_id))
+                if channel and hasattr(channel, "fetch_message"):
+                    msg = await channel.fetch_message(int(menu.message_id))
+                    if msg:
+                        await msg.delete()
+            except Exception as e:
+                logger.warning("Could not delete role menu message %s: %s", menu.message_id, e)
+
+        logger.info("Role menu %s deleted by %s", menu_id, ctx.author.username)
+        await send_success(ctx, "Menu supprimé.")
+
+    @rolemenu_create.subcommand(
+        sub_cmd_name="edit",
+        sub_cmd_description="Modifier le titre ou la description d'un menu existant",
+    )
+    @slash_option(
+        "menu_id",
+        "ID du menu (visible via /rolemenu list)",
+        opt_type=OptionType.STRING,
+        required=True,
+    )
+    @slash_option(
+        "title",
+        "Nouveau titre (optionnel)",
+        opt_type=OptionType.STRING,
+        required=False,
+    )
+    @slash_option(
+        "description",
+        "Nouvelle description (optionnel, laisser vide pour conserver)",
+        opt_type=OptionType.STRING,
+        required=False,
+    )
+    @slash_default_member_permission(Permissions.ADMINISTRATOR | Permissions.MANAGE_ROLES)
+    async def rolemenu_edit(
+        self,
+        ctx: SlashContext,
+        menu_id: str,
+        title: str | None = None,
+        description: str | None = None,
+    ) -> None:
+        if not await require_guild(ctx):
+            return
+        if title is None and description is None:
+            await send_error(ctx, "Indiquez au moins un titre ou une description à modifier.")
+            return
+
+        menu = await self.repository(ctx.guild_id).get(menu_id)
+        if not menu:
+            await send_error(ctx, "Menu introuvable.")
+            return
+
+        new_title = title if title is not None else menu.title
+        new_description = description if description is not None else menu.description
+        await self.repository(ctx.guild_id).update(
+            menu_id, title=new_title, description=new_description
+        )
+
+        if menu.message_id:
+            try:
+                channel = await self.bot.fetch_channel(int(menu.channel_id))
+                if channel and hasattr(channel, "fetch_message"):
+                    msg = await channel.fetch_message(int(menu.message_id))
+                    if msg:
+                        embed = _build_embed(new_title, new_description, menu.entries)
+                        await msg.edit(embeds=[embed])
+            except Exception as e:
+                logger.warning("Could not edit role menu message %s: %s", menu.message_id, e)
+
+        await send_success(ctx, "Menu modifié.")

--- a/extensions/reactionroles/commands.py
+++ b/extensions/reactionroles/commands.py
@@ -3,10 +3,7 @@
 from datetime import datetime
 
 from interactions import (
-    ActionRow,
     BaseChannel,
-    Button,
-    ButtonStyle,
     ChannelType,
     Embed,
     OptionType,
@@ -21,7 +18,7 @@ from features.reactionroles import RoleMenu, RoleMenuEntry
 from src.discord_ext.embeds import Colors
 from src.discord_ext.messages import require_guild, send_error, send_success
 
-from ._common import BUTTON_PREFIX, MAX_ENTRIES, enabled_servers_int, logger
+from ._common import MAX_ENTRIES, build_components, build_embed, enabled_servers_int, logger
 
 
 def _parse_entries(raw: str) -> list[RoleMenuEntry] | str:
@@ -48,30 +45,6 @@ def _parse_entries(raw: str) -> list[RoleMenuEntry] | str:
             return f"Entrée {idx} : libellé trop long (max 80 caractères)."
         entries.append(RoleMenuEntry(role_id=role_id, emoji=emoji, label=label))
     return entries
-
-
-def _build_embed(title: str, description: str | None, entries: list[RoleMenuEntry]) -> Embed:
-    body_lines = [f"{e.emoji} <@&{e.role_id}> — {e.label}" for e in entries]
-    embed_description = (description + "\n\n" if description else "") + "\n".join(body_lines)
-    return Embed(title=title, description=embed_description, color=Colors.UTIL)
-
-
-def _build_components(menu_id: str, entries: list[RoleMenuEntry]) -> list[ActionRow]:
-    rows: list[ActionRow] = []
-    for chunk_start in range(0, len(entries), 5):
-        buttons = []
-        for offset, entry in enumerate(entries[chunk_start : chunk_start + 5]):
-            idx = chunk_start + offset
-            buttons.append(
-                Button(
-                    label=entry.label[:80],
-                    style=ButtonStyle.SECONDARY,
-                    emoji=entry.emoji,
-                    custom_id=f"{BUTTON_PREFIX}:{menu_id}:{idx}",
-                )
-            )
-        rows.append(ActionRow(*buttons))
-    return rows
 
 
 class CommandsMixin:
@@ -150,8 +123,8 @@ class CommandsMixin:
         )
         menu_id = await self.repository(ctx.guild_id).add(menu)
 
-        embed = _build_embed(title, description, parsed)
-        components = _build_components(menu_id, parsed)
+        embed = build_embed(title, description, parsed)
+        components = build_components(menu_id, parsed)
         try:
             sent = await channel.send(embeds=[embed], components=components)  # type: ignore[union-attr]
         except Exception as e:
@@ -287,7 +260,7 @@ class CommandsMixin:
                 if channel and hasattr(channel, "fetch_message"):
                     msg = await channel.fetch_message(int(menu.message_id))
                     if msg:
-                        embed = _build_embed(new_title, new_description, menu.entries)
+                        embed = build_embed(new_title, new_description, menu.entries)
                         await msg.edit(embeds=[embed])
             except Exception as e:
                 logger.warning("Could not edit role menu message %s: %s", menu.message_id, e)

--- a/extensions/starboard/__init__.py
+++ b/extensions/starboard/__init__.py
@@ -1,0 +1,48 @@
+"""Starboard Discord extension — mirror highly-reacted messages to a dedicated channel.
+
+Listens to :class:`MessageReactionAdd` / :class:`MessageReactionRemove`. When a
+message accumulates the configured number of star reactions, it is republished
+as an embed in the configured starboard channel. Subsequent reactions update
+the count; if ``removeBelowThreshold`` is set, dropping below the threshold
+deletes the mirror.
+
+Per-guild config: ``moduleStarboard`` (channel, emoji, threshold, options).
+Persistent state lives in :class:`features.starboard.StarboardRepository`.
+"""
+
+import asyncio
+
+from interactions import Client, Extension, listen
+
+from features.starboard import StarboardRepository
+
+from ._common import enabled_servers, logger
+from .listeners import ListenersMixin
+
+
+class StarboardExtension(Extension, ListenersMixin):
+    def __init__(self, bot: Client):
+        self.bot = bot
+        self.lock = asyncio.Lock()
+        self._repos: dict[str, StarboardRepository] = {}
+
+    def repository(self, guild_id: str | int) -> StarboardRepository:
+        gid = str(guild_id)
+        repo = self._repos.get(gid)
+        if repo is None:
+            repo = StarboardRepository(gid)
+            self._repos[gid] = repo
+        return repo
+
+    @listen()
+    async def on_startup(self):
+        for gid in enabled_servers:
+            await self.repository(gid).ensure_indexes()
+        logger.info("Starboard ready (%d guild(s))", len(enabled_servers))
+
+
+def setup(bot: Client) -> None:
+    StarboardExtension(bot)
+
+
+__all__ = ["StarboardExtension", "setup"]

--- a/extensions/starboard/_common.py
+++ b/extensions/starboard/_common.py
@@ -1,0 +1,73 @@
+"""Config schema, logger, and shared helpers for the starboard extension."""
+
+import os
+
+from src.core import logging as logutil
+from src.core.config import load_config
+from src.webui.schemas import SchemaBase, enabled_field, register_module, ui
+
+logger = logutil.init_logger(os.path.basename(__file__))
+
+
+@register_module("moduleStarboard")
+class StarboardConfig(SchemaBase):
+    __label__ = "Starboard"
+    __description__ = "Mise en avant des messages populaires dans un salon dédié."
+    __icon__ = "⭐"
+    __category__ = "Communauté"
+
+    enabled: bool = enabled_field()
+    starboardChannelId: str = ui(
+        "Salon starboard",
+        "channel",
+        required=True,
+        description="Salon où les messages mis en avant sont republiés.",
+    )
+    emoji: str = ui(
+        "Emoji déclencheur",
+        "string",
+        default="⭐",
+        description="Emoji utilisé pour valider un message (Unicode ou nom :emoji:).",
+    )
+    threshold: int = ui(
+        "Seuil",
+        "number",
+        default=3,
+        description="Nombre minimum de réactions pour publier le message.",
+    )
+    allowSelfStar: bool = ui(
+        "Auto-starring",
+        "boolean",
+        default=False,
+        description="Autoriser un membre à mettre en avant son propre message.",
+    )
+    ignoreBots: bool = ui(
+        "Ignorer les bots",
+        "boolean",
+        default=True,
+        description="Ne pas mettre en avant les messages envoyés par des bots.",
+    )
+    removeBelowThreshold: bool = ui(
+        "Retirer si seuil retombé",
+        "boolean",
+        default=False,
+        description="Supprimer le message du starboard si le compteur passe sous le seuil.",
+    )
+    ignoredChannels: list[str] = ui(
+        "Salons ignorés",
+        "list",
+        description="IDs de salons à exclure du starboard.",
+    )
+
+
+_, module_config, enabled_servers = load_config("moduleStarboard")
+enabled_servers_int = [int(s) for s in enabled_servers]  # type: ignore[misc]
+
+
+def get_guild_settings(guild_id: int | str) -> dict | None:
+    """Return per-guild module config dict, or None if disabled/missing."""
+    sid = str(guild_id)
+    settings = module_config.get(sid)
+    if settings is None and sid.isdigit():
+        settings = module_config.get(int(sid))
+    return settings

--- a/extensions/starboard/listeners.py
+++ b/extensions/starboard/listeners.py
@@ -1,0 +1,238 @@
+"""Reaction listeners that mirror popular messages to the configured starboard."""
+
+from datetime import datetime
+
+from interactions import Embed, listen
+from interactions.api.events import MessageReactionAdd, MessageReactionRemove
+
+from features.starboard import StarEntry
+from src.discord_ext.embeds import Colors
+
+from ._common import get_guild_settings, logger
+
+
+def _jump_url(guild_id: str | int, channel_id: str | int, message_id: str | int) -> str:
+    return f"https://discord.com/channels/{guild_id}/{channel_id}/{message_id}"
+
+
+def _first_image_url(message) -> str | None:
+    """Return the URL of the first image attachment or embed image, if any."""
+    for att in getattr(message, "attachments", []) or []:
+        ctype = (getattr(att, "content_type", None) or "").lower()
+        if ctype.startswith("image/"):
+            return att.url
+        # Fallback by extension if content_type is missing.
+        url = getattr(att, "url", "") or ""
+        if url.lower().rsplit("?", 1)[0].endswith((".png", ".jpg", ".jpeg", ".gif", ".webp")):
+            return url
+    for embed in getattr(message, "embeds", []) or []:
+        img = getattr(embed, "image", None)
+        if img and getattr(img, "url", None):
+            return img.url
+        thumb = getattr(embed, "thumbnail", None)
+        if thumb and getattr(thumb, "url", None):
+            return thumb.url
+    return None
+
+
+def _build_embed(message, count: int, emoji: str) -> Embed:
+    author = message.author
+    author_name = getattr(author, "display_name", None) or getattr(author, "username", "?")
+    avatar_url = None
+    avatar = getattr(author, "avatar_url", None)
+    if avatar:
+        avatar_url = avatar if isinstance(avatar, str) else getattr(avatar, "url", None)
+
+    content = (message.content or "").strip()
+    description = content if content else "*(message sans texte)*"
+
+    embed = Embed(description=description, color=Colors.WARNING)
+    embed.set_author(name=author_name, icon_url=avatar_url)
+    image_url = _first_image_url(message)
+    if image_url:
+        embed.set_image(url=image_url)
+    embed.add_field(
+        name="Source",
+        value=f"[Aller au message]({_jump_url(message.guild.id, message.channel.id, message.id)})",
+        inline=False,
+    )
+    embed.set_footer(text=f"{emoji} {count} • #{getattr(message.channel, 'name', message.channel.id)}")
+    embed.timestamp = getattr(message, "created_at", None) or datetime.now()
+    return embed
+
+
+async def _count_valid_reactions(
+    message,
+    emoji_target: str,
+    *,
+    allow_self: bool,
+    ignore_bots: bool,
+) -> int:
+    """Return the number of users whose reaction with this emoji counts toward the threshold."""
+    for reaction in getattr(message, "reactions", []) or []:
+        if str(reaction.emoji) != emoji_target:
+            continue
+        try:
+            users = await reaction.users().flatten()
+        except Exception as e:
+            logger.debug("Could not list reaction users: %s", e)
+            return reaction.count
+        valid = []
+        for u in users:
+            if ignore_bots and getattr(u, "bot", False):
+                continue
+            if not allow_self and u.id == message.author.id:
+                continue
+            valid.append(u)
+        return len(valid)
+    return 0
+
+
+class ListenersMixin:
+    """React to ⭐ adds/removes and keep the starboard mirror in sync."""
+
+    @listen(MessageReactionAdd)
+    async def on_reaction_add(self, event: MessageReactionAdd) -> None:
+        await self._handle_reaction(event)
+
+    @listen(MessageReactionRemove)
+    async def on_reaction_remove(self, event: MessageReactionRemove) -> None:
+        await self._handle_reaction(event)
+
+    async def _handle_reaction(
+        self, event: MessageReactionAdd | MessageReactionRemove
+    ) -> None:
+        message = event.message
+        if message is None or message.guild is None:
+            return
+
+        settings = get_guild_settings(message.guild.id)
+        if not settings:
+            return
+
+        emoji = settings.get("emoji", "⭐") or "⭐"
+        if str(event.emoji) != emoji:
+            return
+
+        starboard_channel_id = settings.get("starboardChannelId")
+        if not starboard_channel_id:
+            return
+        if str(message.channel.id) == str(starboard_channel_id):
+            return
+
+        ignored = {str(c) for c in (settings.get("ignoredChannels") or []) if c}
+        if str(message.channel.id) in ignored:
+            return
+
+        ignore_bots = bool(settings.get("ignoreBots", True))
+        if ignore_bots and getattr(message.author, "bot", False):
+            return
+
+        threshold = max(1, int(settings.get("threshold", 3) or 3))
+        allow_self = bool(settings.get("allowSelfStar", False))
+
+        async with self.lock:
+            await self._sync_mirror(
+                message=message,
+                guild_id=str(message.guild.id),
+                emoji=emoji,
+                threshold=threshold,
+                allow_self=allow_self,
+                ignore_bots=ignore_bots,
+                starboard_channel_id=str(starboard_channel_id),
+                remove_below_threshold=bool(settings.get("removeBelowThreshold", False)),
+            )
+
+    async def _sync_mirror(
+        self,
+        *,
+        message,
+        guild_id: str,
+        emoji: str,
+        threshold: int,
+        allow_self: bool,
+        ignore_bots: bool,
+        starboard_channel_id: str,
+        remove_below_threshold: bool,
+    ) -> None:
+        repo = self.repository(guild_id)
+        existing = await repo.get_by_original(str(message.id))
+
+        count = await _count_valid_reactions(
+            message,
+            emoji,
+            allow_self=allow_self,
+            ignore_bots=ignore_bots,
+        )
+
+        if count >= threshold and existing is None:
+            try:
+                channel = await self.bot.fetch_channel(int(starboard_channel_id))
+            except Exception as e:
+                logger.error("Cannot fetch starboard channel %s: %s", starboard_channel_id, e)
+                return
+            if channel is None or not hasattr(channel, "send"):
+                return
+
+            embed = _build_embed(message, count, emoji)
+            try:
+                sent = await channel.send(embeds=[embed])  # type: ignore[union-attr]
+            except Exception as e:
+                logger.error("Failed to publish to starboard: %s", e)
+                return
+
+            entry = StarEntry(
+                guild_id=guild_id,
+                channel_id=str(message.channel.id),
+                original_message_id=str(message.id),
+                mirror_channel_id=str(channel.id),
+                mirror_message_id=str(sent.id),
+                author_id=str(message.author.id),
+                count=count,
+                created_at=datetime.now(),
+            )
+            await repo.upsert(entry)
+            logger.info(
+                "Starboard: posted message %s (count=%d) in guild %s", message.id, count, guild_id
+            )
+            return
+
+        if existing is not None and count >= threshold:
+            if existing.count == count:
+                return
+            try:
+                channel = await self.bot.fetch_channel(int(existing.mirror_channel_id))
+                if channel and hasattr(channel, "fetch_message"):
+                    msg = await channel.fetch_message(int(existing.mirror_message_id))
+                    if msg:
+                        embed = _build_embed(message, count, emoji)
+                        await msg.edit(embeds=[embed])
+            except Exception as e:
+                logger.warning("Could not refresh starboard mirror: %s", e)
+            await repo.update_count(str(message.id), count)
+            return
+
+        if existing is not None and count < threshold:
+            if remove_below_threshold:
+                try:
+                    channel = await self.bot.fetch_channel(int(existing.mirror_channel_id))
+                    if channel and hasattr(channel, "fetch_message"):
+                        msg = await channel.fetch_message(int(existing.mirror_message_id))
+                        if msg:
+                            await msg.delete()
+                except Exception as e:
+                    logger.warning("Could not delete starboard mirror: %s", e)
+                await repo.delete_by_original(str(message.id))
+                logger.info("Starboard: removed message %s (count fell to %d)", message.id, count)
+            else:
+                # Keep the mirror but refresh the count footer.
+                try:
+                    channel = await self.bot.fetch_channel(int(existing.mirror_channel_id))
+                    if channel and hasattr(channel, "fetch_message"):
+                        msg = await channel.fetch_message(int(existing.mirror_message_id))
+                        if msg:
+                            embed = _build_embed(message, count, emoji)
+                            await msg.edit(embeds=[embed])
+                except Exception as e:
+                    logger.warning("Could not refresh starboard mirror: %s", e)
+                await repo.update_count(str(message.id), count)

--- a/extensions/starboard/listeners.py
+++ b/extensions/starboard/listeners.py
@@ -56,7 +56,9 @@ def _build_embed(message, count: int, emoji: str) -> Embed:
         value=f"[Aller au message]({_jump_url(message.guild.id, message.channel.id, message.id)})",
         inline=False,
     )
-    embed.set_footer(text=f"{emoji} {count} • #{getattr(message.channel, 'name', message.channel.id)}")
+    embed.set_footer(
+        text=f"{emoji} {count} • #{getattr(message.channel, 'name', message.channel.id)}"
+    )
     embed.timestamp = getattr(message, "created_at", None) or datetime.now()
     return embed
 
@@ -99,9 +101,7 @@ class ListenersMixin:
     async def on_reaction_remove(self, event: MessageReactionRemove) -> None:
         await self._handle_reaction(event)
 
-    async def _handle_reaction(
-        self, event: MessageReactionAdd | MessageReactionRemove
-    ) -> None:
+    async def _handle_reaction(self, event: MessageReactionAdd | MessageReactionRemove) -> None:
         message = event.message
         if message is None or message.guild is None:
             return

--- a/extensions/suggestions/__init__.py
+++ b/extensions/suggestions/__init__.py
@@ -1,0 +1,44 @@
+"""Suggestions Discord extension — community suggestion box with up/down voting.
+
+Slash commands:
+- ``/suggest`` — anyone can submit a suggestion (published in the configured channel)
+- ``/suggestion approve|deny|implement`` — staff-only status updates
+
+Buttons (👍 / 👎) are persistent: callbacks rebind on extension load. Per-guild
+config: ``moduleSuggestions`` (channel, staff role, optional anonymity).
+"""
+
+from interactions import Client, Extension, listen
+
+from features.suggestions import SuggestionsRepository
+
+from ._common import enabled_servers, logger
+from .buttons import ButtonsMixin
+from .commands import CommandsMixin
+
+
+class SuggestionsExtension(Extension, CommandsMixin, ButtonsMixin):
+    def __init__(self, bot: Client):
+        self.bot = bot
+        self._repos: dict[str, SuggestionsRepository] = {}
+
+    def repository(self, guild_id: str | int) -> SuggestionsRepository:
+        gid = str(guild_id)
+        repo = self._repos.get(gid)
+        if repo is None:
+            repo = SuggestionsRepository(gid)
+            self._repos[gid] = repo
+        return repo
+
+    @listen()
+    async def on_startup(self):
+        for gid in enabled_servers:
+            await self.repository(gid).ensure_indexes()
+        logger.info("Suggestions ready (%d guild(s))", len(enabled_servers))
+
+
+def setup(bot: Client) -> None:
+    SuggestionsExtension(bot)
+
+
+__all__ = ["SuggestionsExtension", "setup"]

--- a/extensions/suggestions/_common.py
+++ b/extensions/suggestions/_common.py
@@ -1,0 +1,67 @@
+"""Config schema, logger, and shared constants for the suggestions extension."""
+
+import os
+
+from src.core import logging as logutil
+from src.core.config import load_config
+from src.discord_ext.embeds import Colors
+from src.webui.schemas import SchemaBase, enabled_field, register_module, ui
+
+logger = logutil.init_logger(os.path.basename(__file__))
+
+
+@register_module("moduleSuggestions")
+class SuggestionsConfig(SchemaBase):
+    __label__ = "Boîte à suggestions"
+    __description__ = "Permet aux membres de proposer des idées avec votes et statut."
+    __icon__ = "💡"
+    __category__ = "Communauté"
+
+    enabled: bool = enabled_field()
+    suggestChannelId: str = ui(
+        "Salon suggestions",
+        "channel",
+        required=True,
+        description="Salon où les suggestions sont publiées.",
+    )
+    staffRoleId: str | None = ui(
+        "Rôle staff",
+        "role",
+        description="Rôle autorisé à approuver/refuser les suggestions (sinon admin uniquement).",
+    )
+    anonymous: bool = ui(
+        "Suggestions anonymes",
+        "boolean",
+        default=False,
+        description="Masquer l'auteur de la suggestion dans l'embed public.",
+    )
+
+
+_, module_config, enabled_servers = load_config("moduleSuggestions")
+enabled_servers_int = [int(s) for s in enabled_servers]  # type: ignore[misc]
+
+# Persistent button namespace: suggvote:{sugg_id}:{up|down}
+VOTE_PREFIX = "suggvote"
+
+STATUS_COLORS: dict[str, int] = {
+    "pending": Colors.UTIL,
+    "approved": Colors.SUCCESS,
+    "denied": Colors.ERROR,
+    "implemented": Colors.SPOTIFY,
+}
+
+STATUS_LABELS: dict[str, str] = {
+    "pending": "🟦 En attente",
+    "approved": "✅ Approuvée",
+    "denied": "❌ Refusée",
+    "implemented": "🚀 Implémentée",
+}
+
+
+def get_guild_settings(guild_id: int | str) -> dict | None:
+    """Return the per-guild module config, or None if disabled/missing."""
+    sid = str(guild_id)
+    settings = module_config.get(sid)
+    if settings is None and sid.isdigit():
+        settings = module_config.get(int(sid))
+    return settings

--- a/extensions/suggestions/buttons.py
+++ b/extensions/suggestions/buttons.py
@@ -1,0 +1,67 @@
+"""Persistent vote button — toggle/replace the user's up/down vote."""
+
+import re
+
+from interactions import ComponentContext, component_callback
+
+from src.discord_ext.messages import send_error
+
+from ._common import VOTE_PREFIX, get_guild_settings, logger
+
+_CUSTOM_ID_RE = re.compile(rf"^{VOTE_PREFIX}:(\d+):(up|down)$")
+
+
+class ButtonsMixin:
+    """Handle 👍 / 👎 clicks on suggestion embeds."""
+
+    @component_callback(_CUSTOM_ID_RE)
+    async def on_vote_button(self, ctx: ComponentContext) -> None:
+        if not ctx.guild:
+            await send_error(ctx, "Cette action n'est disponible qu'en serveur.")
+            return
+
+        match = _CUSTOM_ID_RE.match(ctx.custom_id)
+        if not match:
+            return
+        sugg_id, direction = int(match.group(1)), match.group(2)
+
+        settings = get_guild_settings(ctx.guild_id)
+        if not settings:
+            await send_error(ctx, "Le module suggestions n'est plus actif.")
+            return
+
+        repo = self.repository(ctx.guild_id)
+        existing = await repo.get(sugg_id)
+        if not existing:
+            await send_error(ctx, "Cette suggestion n'existe plus.")
+            return
+        if existing.status != "pending":
+            await send_error(ctx, "Le vote est clos pour cette suggestion.")
+            return
+
+        user_id = str(ctx.author.id)
+        previous = existing.votes.get(user_id)
+        if previous == direction:
+            updated = await repo.remove_vote(sugg_id, user_id)
+            action_text = "Vote retiré"
+        else:
+            updated = await repo.set_vote(sugg_id, user_id, direction)
+            action_text = "Vote 👍 enregistré" if direction == "up" else "Vote 👎 enregistré"
+
+        if not updated:
+            await send_error(ctx, "Impossible d'enregistrer le vote.")
+            return
+
+        # Update the original embed's Votes field in place.
+        try:
+            up, down = updated.tally()
+            embed = ctx.message.embeds[0]
+            for field in embed.fields or []:
+                if field.name == "Votes":
+                    field.value = f"👍 {up} · 👎 {down}"
+                    break
+            await ctx.message.edit(embeds=[embed])
+        except Exception as e:
+            logger.warning("Could not refresh suggestion #%s embed: %s", sugg_id, e)
+
+        await ctx.send(action_text, ephemeral=True)

--- a/extensions/suggestions/commands.py
+++ b/extensions/suggestions/commands.py
@@ -1,0 +1,304 @@
+"""Slash commands: ``/suggest`` (anyone) and ``/suggestion approve|deny|implement`` (staff)."""
+
+from datetime import datetime
+
+from interactions import (
+    ActionRow,
+    Button,
+    ButtonStyle,
+    Embed,
+    OptionType,
+    Permissions,
+    SlashContext,
+    slash_command,
+    slash_option,
+)
+
+from features.suggestions import Suggestion
+from src.discord_ext.embeds import Colors
+from src.discord_ext.messages import require_guild, send_error, send_success
+
+from ._common import (
+    STATUS_COLORS,
+    STATUS_LABELS,
+    VOTE_PREFIX,
+    enabled_servers_int,
+    get_guild_settings,
+    logger,
+)
+
+
+def _build_embed(
+    suggestion: Suggestion,
+    *,
+    anonymous: bool,
+    bot_name: str = "",
+) -> Embed:
+    up, down = suggestion.tally()
+    author_value = "Anonyme" if anonymous else f"<@{suggestion.author_id}>"
+
+    embed = Embed(
+        title=f"Suggestion #{suggestion.id}",
+        description=suggestion.text,
+        color=STATUS_COLORS.get(suggestion.status, Colors.UTIL),
+    )
+    embed.add_field(name="Statut", value=STATUS_LABELS[suggestion.status], inline=True)
+    embed.add_field(name="Auteur", value=author_value, inline=True)
+    embed.add_field(name="Votes", value=f"👍 {up} · 👎 {down}", inline=True)
+
+    if suggestion.status != "pending" and (suggestion.reason or suggestion.decided_by):
+        details = []
+        if suggestion.decided_by:
+            details.append(f"Décision : <@{suggestion.decided_by}>")
+        if suggestion.reason:
+            details.append(f"Motif : {suggestion.reason}")
+        embed.add_field(name="​", value="\n".join(details), inline=False)
+
+    embed.timestamp = suggestion.created_at
+    if bot_name:
+        embed.set_footer(text=bot_name)
+    return embed
+
+
+def _vote_components(sugg_id: int, *, disabled: bool = False) -> list[ActionRow]:
+    return [
+        ActionRow(
+            Button(
+                label="Pour",
+                style=ButtonStyle.SUCCESS,
+                emoji="👍",
+                custom_id=f"{VOTE_PREFIX}:{sugg_id}:up",
+                disabled=disabled,
+            ),
+            Button(
+                label="Contre",
+                style=ButtonStyle.DANGER,
+                emoji="👎",
+                custom_id=f"{VOTE_PREFIX}:{sugg_id}:down",
+                disabled=disabled,
+            ),
+        )
+    ]
+
+
+def _is_staff(ctx: SlashContext, settings: dict) -> bool:
+    """True if the caller has the configured staff role, or administrator perms."""
+    member = ctx.author
+    try:
+        if member.has_permission(Permissions.ADMINISTRATOR):
+            return True
+    except Exception:
+        pass
+    staff_role_id = settings.get("staffRoleId")
+    if not staff_role_id:
+        return False
+    try:
+        return any(int(getattr(r, "id", r)) == int(staff_role_id) for r in member.roles)
+    except Exception:
+        return False
+
+
+class CommandsMixin:
+    """Public ``/suggest`` and staff-only ``/suggestion ...`` sub-commands."""
+
+    @slash_command(
+        name="suggest",
+        description="Proposer une suggestion à la communauté",
+        scopes=enabled_servers_int,  # type: ignore
+    )
+    @slash_option(
+        "texte",
+        "Contenu de la suggestion",
+        opt_type=OptionType.STRING,
+        required=True,
+        argument_name="text",
+    )
+    async def suggest(self, ctx: SlashContext, text: str) -> None:
+        if not await require_guild(ctx):
+            return
+        settings = get_guild_settings(ctx.guild_id)
+        if not settings:
+            await send_error(ctx, "Le module suggestions n'est pas activé sur ce serveur.")
+            return
+
+        if len(text) > 1500:
+            await send_error(ctx, "La suggestion est trop longue (max 1500 caractères).")
+            return
+
+        channel_id = settings.get("suggestChannelId")
+        if not channel_id:
+            await send_error(ctx, "Aucun salon de suggestions n'est configuré.")
+            return
+
+        try:
+            channel = await self.bot.fetch_channel(int(channel_id))
+        except Exception:
+            channel = None
+        if channel is None or not hasattr(channel, "send"):
+            await send_error(ctx, "Salon de suggestions introuvable.")
+            return
+
+        await ctx.defer(ephemeral=True)
+
+        repo = self.repository(ctx.guild_id)
+        sugg_id = await repo.next_id()
+        suggestion = Suggestion(
+            id=sugg_id,
+            guild_id=str(ctx.guild_id),
+            channel_id=str(channel.id),
+            author_id=str(ctx.author.id),
+            text=text,
+            created_at=datetime.now(),
+        )
+        await repo.add(suggestion)
+
+        anonymous = bool(settings.get("anonymous", False))
+        embed = _build_embed(suggestion, anonymous=anonymous)
+        components = _vote_components(sugg_id)
+
+        try:
+            sent = await channel.send(embeds=[embed], components=components)  # type: ignore[union-attr]
+        except Exception as e:
+            logger.error("Failed to publish suggestion %s: %s", sugg_id, e)
+            await send_error(ctx, "Impossible de publier la suggestion.")
+            return
+
+        await repo.set_message(sugg_id, str(sent.id))
+        logger.info(
+            "Suggestion #%s created by %s in guild %s", sugg_id, ctx.author.username, ctx.guild_id
+        )
+        await send_success(ctx, f"Suggestion **#{sugg_id}** publiée.")
+
+    @slash_command(
+        name="suggestion",
+        description="Gérer les suggestions (staff)",
+        sub_cmd_name="approve",
+        sub_cmd_description="Approuver une suggestion",
+        scopes=enabled_servers_int,  # type: ignore
+    )
+    @slash_option(
+        "id",
+        "ID de la suggestion",
+        opt_type=OptionType.INTEGER,
+        required=True,
+        min_value=1,
+        argument_name="sugg_id",
+    )
+    @slash_option(
+        "motif",
+        "Motif optionnel",
+        opt_type=OptionType.STRING,
+        required=False,
+        argument_name="reason",
+    )
+    async def suggestion_approve(
+        self, ctx: SlashContext, sugg_id: int, reason: str | None = None
+    ) -> None:
+        await self._handle_decision(ctx, sugg_id, "approved", reason)
+
+    @suggestion_approve.subcommand(
+        sub_cmd_name="deny",
+        sub_cmd_description="Refuser une suggestion",
+    )
+    @slash_option(
+        "id",
+        "ID de la suggestion",
+        opt_type=OptionType.INTEGER,
+        required=True,
+        min_value=1,
+        argument_name="sugg_id",
+    )
+    @slash_option(
+        "motif",
+        "Motif optionnel",
+        opt_type=OptionType.STRING,
+        required=False,
+        argument_name="reason",
+    )
+    async def suggestion_deny(
+        self, ctx: SlashContext, sugg_id: int, reason: str | None = None
+    ) -> None:
+        await self._handle_decision(ctx, sugg_id, "denied", reason)
+
+    @suggestion_approve.subcommand(
+        sub_cmd_name="implement",
+        sub_cmd_description="Marquer une suggestion comme implémentée",
+    )
+    @slash_option(
+        "id",
+        "ID de la suggestion",
+        opt_type=OptionType.INTEGER,
+        required=True,
+        min_value=1,
+        argument_name="sugg_id",
+    )
+    @slash_option(
+        "motif",
+        "Note optionnelle",
+        opt_type=OptionType.STRING,
+        required=False,
+        argument_name="reason",
+    )
+    async def suggestion_implement(
+        self, ctx: SlashContext, sugg_id: int, reason: str | None = None
+    ) -> None:
+        await self._handle_decision(ctx, sugg_id, "implemented", reason)
+
+    async def _handle_decision(
+        self,
+        ctx: SlashContext,
+        sugg_id: int,
+        status: str,
+        reason: str | None,
+    ) -> None:
+        if not await require_guild(ctx):
+            return
+        settings = get_guild_settings(ctx.guild_id)
+        if not settings:
+            await send_error(ctx, "Le module suggestions n'est pas activé sur ce serveur.")
+            return
+        if not _is_staff(ctx, settings):
+            await send_error(ctx, "Réservé au staff.")
+            return
+
+        repo = self.repository(ctx.guild_id)
+        suggestion = await repo.get(sugg_id)
+        if not suggestion:
+            await send_error(ctx, f"Suggestion #{sugg_id} introuvable.")
+            return
+
+        await repo.update_status(sugg_id, status, reason, str(ctx.author.id))  # type: ignore[arg-type]
+        suggestion.status = status  # type: ignore[assignment]
+        suggestion.reason = reason
+        suggestion.decided_by = str(ctx.author.id)
+
+        anonymous = bool(settings.get("anonymous", False))
+        embed = _build_embed(suggestion, anonymous=anonymous)
+
+        if suggestion.message_id:
+            try:
+                channel = await self.bot.fetch_channel(int(suggestion.channel_id))
+                if channel and hasattr(channel, "fetch_message"):
+                    msg = await channel.fetch_message(int(suggestion.message_id))
+                    if msg:
+                        # Disable vote buttons once a decision has been made.
+                        await msg.edit(
+                            embeds=[embed],
+                            components=_vote_components(sugg_id, disabled=True),
+                        )
+                        if not anonymous:
+                            await channel.send(  # type: ignore[union-attr]
+                                f"<@{suggestion.author_id}> ta suggestion **#{sugg_id}** a "
+                                f"été {STATUS_LABELS[status]}."
+                            )
+            except Exception as e:
+                logger.warning("Could not update suggestion #%s message: %s", sugg_id, e)
+
+        logger.info(
+            "Suggestion #%s -> %s by %s (guild %s)",
+            sugg_id,
+            status,
+            ctx.author.username,
+            ctx.guild_id,
+        )
+        await send_success(ctx, f"Suggestion **#{sugg_id}** {STATUS_LABELS[status]}.")

--- a/features/reactionroles/__init__.py
+++ b/features/reactionroles/__init__.py
@@ -1,0 +1,8 @@
+from features.reactionroles.models import RoleMenu, RoleMenuEntry
+from features.reactionroles.repository import ReactionRolesRepository
+
+__all__ = [
+    "ReactionRolesRepository",
+    "RoleMenu",
+    "RoleMenuEntry",
+]

--- a/features/reactionroles/__init__.py
+++ b/features/reactionroles/__init__.py
@@ -1,8 +1,18 @@
+from features.reactionroles.builders import (
+    BUTTON_PREFIX,
+    MAX_ENTRIES,
+    build_components,
+    build_embed,
+)
 from features.reactionroles.models import RoleMenu, RoleMenuEntry
 from features.reactionroles.repository import ReactionRolesRepository
 
 __all__ = [
+    "BUTTON_PREFIX",
+    "MAX_ENTRIES",
     "ReactionRolesRepository",
     "RoleMenu",
     "RoleMenuEntry",
+    "build_components",
+    "build_embed",
 ]

--- a/features/reactionroles/builders.py
+++ b/features/reactionroles/builders.py
@@ -1,0 +1,43 @@
+"""Discord embed and component builders for role menus.
+
+Lives in ``features/`` (not ``extensions/``) so the slash-command extension
+and the WebUI route can share the exact same renderer without crossing
+package boundaries.
+"""
+
+from interactions import ActionRow, Button, ButtonStyle, Embed
+
+from features.reactionroles.models import RoleMenuEntry
+from src.discord_ext.embeds import Colors
+
+# Discord caps action rows at 5 buttons each, max 5 rows per message.
+MAX_ENTRIES = 25
+
+# Persistent button namespace: rrole:{menu_id}:{entry_idx}
+BUTTON_PREFIX = "rrole"
+
+
+def build_embed(title: str, description: str | None, entries: list[RoleMenuEntry]) -> Embed:
+    """Render a role-menu embed (title, optional description, role/emoji/label list)."""
+    body_lines = [f"{e.emoji} <@&{e.role_id}> — {e.label}" for e in entries]
+    embed_description = (description + "\n\n" if description else "") + "\n".join(body_lines)
+    return Embed(title=title, description=embed_description, color=Colors.UTIL)
+
+
+def build_components(menu_id: str, entries: list[RoleMenuEntry]) -> list[ActionRow]:
+    """Render the action rows of buttons whose ``custom_id`` toggles each role."""
+    rows: list[ActionRow] = []
+    for chunk_start in range(0, len(entries), 5):
+        buttons = []
+        for offset, entry in enumerate(entries[chunk_start : chunk_start + 5]):
+            idx = chunk_start + offset
+            buttons.append(
+                Button(
+                    label=entry.label[:80],
+                    style=ButtonStyle.SECONDARY,
+                    emoji=entry.emoji,
+                    custom_id=f"{BUTTON_PREFIX}:{menu_id}:{idx}",
+                )
+            )
+        rows.append(ActionRow(*buttons))
+    return rows

--- a/features/reactionroles/models.py
+++ b/features/reactionroles/models.py
@@ -1,0 +1,29 @@
+"""Pydantic models for the reaction-roles feature."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class RoleMenuEntry(BaseModel):
+    """A single (role, emoji, label) tuple inside a role menu."""
+
+    role_id: str
+    emoji: str
+    label: str
+
+
+class RoleMenu(BaseModel):
+    """A persistent role-menu message attached to a Discord channel."""
+
+    id: str | None = Field(default=None, alias="_id")
+    guild_id: str
+    channel_id: str
+    message_id: str | None = None
+    title: str
+    description: str | None = None
+    entries: list[RoleMenuEntry]
+    created_by: str
+    created_at: datetime
+
+    model_config = {"populate_by_name": True}

--- a/features/reactionroles/repository.py
+++ b/features/reactionroles/repository.py
@@ -1,0 +1,87 @@
+"""MongoDB I/O for the reaction-roles feature — one document per role menu."""
+
+import os
+from typing import Any
+
+import pymongo
+from bson import ObjectId
+
+from features.reactionroles.models import RoleMenu
+from src.core.db import mongo_manager
+from src.core.errors import DatabaseError
+from src.core.logging import init_logger
+
+logger = init_logger(os.path.basename(__file__))
+
+COLLECTION = "role_menus"
+
+
+class ReactionRolesRepository:
+    """Per-guild store for role menus."""
+
+    def __init__(self, guild_id: str | int) -> None:
+        self._guild_id = str(guild_id)
+
+    def _col(self):
+        return mongo_manager.get_guild_collection(self._guild_id, COLLECTION)
+
+    async def ensure_indexes(self) -> None:
+        try:
+            await self._col().create_index(
+                [("message_id", pymongo.ASCENDING)], name="message_id_idx"
+            )
+        except Exception as e:
+            logger.error("Failed to create role_menus indexes for guild %s: %s", self._guild_id, e)
+
+    @staticmethod
+    def _doc_to_menu(doc: dict) -> RoleMenu:
+        doc = dict(doc)
+        if "_id" in doc:
+            doc["_id"] = str(doc["_id"])
+        return RoleMenu(**doc)
+
+    async def add(self, menu: RoleMenu) -> str:
+        try:
+            payload = menu.model_dump(exclude={"id"})
+            result = await self._col().insert_one(payload)
+            return str(result.inserted_id)
+        except Exception as e:
+            logger.error("DB insert_one failed: %s", e)
+            raise DatabaseError(f"Failed to add role menu: {e}") from e
+
+    async def get(self, menu_id: str) -> RoleMenu | None:
+        try:
+            doc = await self._col().find_one({"_id": ObjectId(menu_id)})
+        except Exception as e:
+            logger.error("DB find_one failed: %s", e)
+            return None
+        return self._doc_to_menu(doc) if doc else None
+
+    async def list(self) -> list[RoleMenu]:
+        try:
+            cursor = self._col().find().sort("created_at", pymongo.DESCENDING)
+            docs = await cursor.to_list(length=None)
+            return [self._doc_to_menu(d) for d in docs]
+        except Exception as e:
+            logger.error("DB find failed: %s", e)
+            raise DatabaseError(f"Failed to list role menus: {e}") from e
+
+    async def update(self, menu_id: str, **fields: Any) -> int:
+        if not fields:
+            return 0
+        try:
+            result = await self._col().update_one(
+                {"_id": ObjectId(menu_id)}, {"$set": fields}
+            )
+            return result.modified_count
+        except Exception as e:
+            logger.error("DB update_one failed: %s", e)
+            raise DatabaseError(f"Failed to update role menu: {e}") from e
+
+    async def delete(self, menu_id: str) -> int:
+        try:
+            result = await self._col().delete_one({"_id": ObjectId(menu_id)})
+            return result.deleted_count
+        except Exception as e:
+            logger.error("DB delete_one failed: %s", e)
+            raise DatabaseError(f"Failed to delete role menu: {e}") from e

--- a/features/reactionroles/repository.py
+++ b/features/reactionroles/repository.py
@@ -70,9 +70,7 @@ class ReactionRolesRepository:
         if not fields:
             return 0
         try:
-            result = await self._col().update_one(
-                {"_id": ObjectId(menu_id)}, {"$set": fields}
-            )
+            result = await self._col().update_one({"_id": ObjectId(menu_id)}, {"$set": fields})
             return result.modified_count
         except Exception as e:
             logger.error("DB update_one failed: %s", e)

--- a/features/starboard/__init__.py
+++ b/features/starboard/__init__.py
@@ -1,0 +1,7 @@
+from features.starboard.models import StarEntry
+from features.starboard.repository import StarboardRepository
+
+__all__ = [
+    "StarEntry",
+    "StarboardRepository",
+]

--- a/features/starboard/models.py
+++ b/features/starboard/models.py
@@ -1,0 +1,21 @@
+"""Pydantic models for the starboard feature."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class StarEntry(BaseModel):
+    """Maps an original message to its starboard mirror message."""
+
+    id: str | None = Field(default=None, alias="_id")  # = original_message_id
+    guild_id: str
+    channel_id: str
+    original_message_id: str
+    mirror_channel_id: str
+    mirror_message_id: str
+    author_id: str
+    count: int
+    created_at: datetime
+
+    model_config = {"populate_by_name": True}

--- a/features/starboard/repository.py
+++ b/features/starboard/repository.py
@@ -1,0 +1,78 @@
+"""MongoDB I/O for the starboard feature — one document per starred message.
+
+The original message id doubles as the document ``_id`` for O(1) lookup.
+"""
+
+import os
+
+import pymongo
+
+from features.starboard.models import StarEntry
+from src.core.db import mongo_manager
+from src.core.errors import DatabaseError
+from src.core.logging import init_logger
+
+logger = init_logger(os.path.basename(__file__))
+
+COLLECTION = "starboard"
+
+
+class StarboardRepository:
+    """Per-guild store for starboard mappings."""
+
+    def __init__(self, guild_id: str | int) -> None:
+        self._guild_id = str(guild_id)
+
+    def _col(self):
+        return mongo_manager.get_guild_collection(self._guild_id, COLLECTION)
+
+    async def ensure_indexes(self) -> None:
+        try:
+            await self._col().create_index(
+                [("mirror_message_id", pymongo.ASCENDING)], name="mirror_message_id_idx"
+            )
+        except Exception as e:
+            logger.error("Failed to create starboard indexes for %s: %s", self._guild_id, e)
+
+    @staticmethod
+    def _doc_to_entry(doc: dict) -> StarEntry:
+        doc = dict(doc)
+        if "_id" in doc:
+            doc["_id"] = str(doc["_id"])
+        return StarEntry(**doc)
+
+    async def get_by_original(self, original_message_id: str) -> StarEntry | None:
+        try:
+            doc = await self._col().find_one({"_id": str(original_message_id)})
+        except Exception as e:
+            logger.error("DB find_one failed: %s", e)
+            return None
+        return self._doc_to_entry(doc) if doc else None
+
+    async def upsert(self, entry: StarEntry) -> None:
+        try:
+            payload = entry.model_dump(exclude={"id"})
+            payload["_id"] = entry.original_message_id
+            await self._col().update_one(
+                {"_id": entry.original_message_id}, {"$set": payload}, upsert=True
+            )
+        except Exception as e:
+            logger.error("DB upsert failed: %s", e)
+            raise DatabaseError(f"Failed to upsert starboard entry: {e}") from e
+
+    async def update_count(self, original_message_id: str, count: int) -> None:
+        try:
+            await self._col().update_one(
+                {"_id": str(original_message_id)}, {"$set": {"count": count}}
+            )
+        except Exception as e:
+            logger.error("DB update_one failed: %s", e)
+            raise DatabaseError(f"Failed to update star count: {e}") from e
+
+    async def delete_by_original(self, original_message_id: str) -> int:
+        try:
+            result = await self._col().delete_one({"_id": str(original_message_id)})
+            return result.deleted_count
+        except Exception as e:
+            logger.error("DB delete_one failed: %s", e)
+            raise DatabaseError(f"Failed to delete starboard entry: {e}") from e

--- a/features/suggestions/__init__.py
+++ b/features/suggestions/__init__.py
@@ -1,0 +1,8 @@
+from features.suggestions.models import Suggestion, SuggestionStatus
+from features.suggestions.repository import SuggestionsRepository
+
+__all__ = [
+    "Suggestion",
+    "SuggestionStatus",
+    "SuggestionsRepository",
+]

--- a/features/suggestions/models.py
+++ b/features/suggestions/models.py
@@ -1,0 +1,33 @@
+"""Pydantic models for the suggestions feature."""
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+SuggestionStatus = Literal["pending", "approved", "denied", "implemented"]
+
+
+class Suggestion(BaseModel):
+    """A single suggestion submitted via ``/suggest``."""
+
+    object_id: str | None = Field(default=None, alias="_id")
+    id: int  # human-readable, auto-incrementing per guild
+    guild_id: str
+    channel_id: str
+    message_id: str | None = None
+    author_id: str
+    text: str
+    status: SuggestionStatus = "pending"
+    reason: str | None = None
+    decided_by: str | None = None
+    votes: dict[str, str] = Field(default_factory=dict)  # user_id -> "up" | "down"
+    created_at: datetime
+
+    model_config = {"populate_by_name": True}
+
+    def tally(self) -> tuple[int, int]:
+        """Return (up_count, down_count)."""
+        up = sum(1 for v in self.votes.values() if v == "up")
+        down = sum(1 for v in self.votes.values() if v == "down")
+        return up, down

--- a/features/suggestions/repository.py
+++ b/features/suggestions/repository.py
@@ -40,9 +40,7 @@ class SuggestionsRepository:
             await self._col().create_index(
                 [("message_id", pymongo.ASCENDING)], name="message_id_idx"
             )
-            await self._col().create_index(
-                [("status", pymongo.ASCENDING)], name="status_idx"
-            )
+            await self._col().create_index([("status", pymongo.ASCENDING)], name="status_idx")
         except Exception as e:
             logger.error("Failed to create suggestions indexes for %s: %s", self._guild_id, e)
 

--- a/features/suggestions/repository.py
+++ b/features/suggestions/repository.py
@@ -1,0 +1,150 @@
+"""MongoDB I/O for the suggestions feature.
+
+One ``suggestions`` collection per guild plus a ``suggestions_meta`` collection
+holding a single counter document used to mint per-guild human IDs.
+"""
+
+import os
+from datetime import datetime
+
+import pymongo
+from pymongo import ReturnDocument
+
+from features.suggestions.models import Suggestion, SuggestionStatus
+from src.core.db import mongo_manager
+from src.core.errors import DatabaseError
+from src.core.logging import init_logger
+
+logger = init_logger(os.path.basename(__file__))
+
+COLLECTION = "suggestions"
+META_COLLECTION = "suggestions_meta"
+COUNTER_ID = "counter"
+
+
+class SuggestionsRepository:
+    """Per-guild store for suggestions + auto-incrementing IDs."""
+
+    def __init__(self, guild_id: str | int) -> None:
+        self._guild_id = str(guild_id)
+
+    def _col(self):
+        return mongo_manager.get_guild_collection(self._guild_id, COLLECTION)
+
+    def _meta_col(self):
+        return mongo_manager.get_guild_collection(self._guild_id, META_COLLECTION)
+
+    async def ensure_indexes(self) -> None:
+        try:
+            await self._col().create_index([("id", pymongo.ASCENDING)], unique=True, name="id_idx")
+            await self._col().create_index(
+                [("message_id", pymongo.ASCENDING)], name="message_id_idx"
+            )
+            await self._col().create_index(
+                [("status", pymongo.ASCENDING)], name="status_idx"
+            )
+        except Exception as e:
+            logger.error("Failed to create suggestions indexes for %s: %s", self._guild_id, e)
+
+    async def next_id(self) -> int:
+        try:
+            doc = await self._meta_col().find_one_and_update(
+                {"_id": COUNTER_ID},
+                {"$inc": {"value": 1}},
+                upsert=True,
+                return_document=ReturnDocument.AFTER,
+            )
+            return int(doc["value"])
+        except Exception as e:
+            logger.error("Counter increment failed: %s", e)
+            raise DatabaseError(f"Failed to mint suggestion id: {e}") from e
+
+    @staticmethod
+    def _doc_to_suggestion(doc: dict) -> Suggestion:
+        doc = dict(doc)
+        if "_id" in doc:
+            doc["_id"] = str(doc["_id"])
+        return Suggestion(**doc)
+
+    async def add(self, suggestion: Suggestion) -> Suggestion:
+        try:
+            payload = suggestion.model_dump(exclude={"object_id"})
+            result = await self._col().insert_one(payload)
+            suggestion.object_id = str(result.inserted_id)
+            return suggestion
+        except Exception as e:
+            logger.error("DB insert_one failed: %s", e)
+            raise DatabaseError(f"Failed to add suggestion: {e}") from e
+
+    async def get(self, sugg_id: int) -> Suggestion | None:
+        try:
+            doc = await self._col().find_one({"id": sugg_id})
+        except Exception as e:
+            logger.error("DB find_one failed: %s", e)
+            return None
+        return self._doc_to_suggestion(doc) if doc else None
+
+    async def list(self, status: SuggestionStatus | None = None) -> list[Suggestion]:
+        try:
+            query = {"status": status} if status else {}
+            cursor = self._col().find(query).sort("created_at", pymongo.DESCENDING)
+            docs = await cursor.to_list(length=None)
+            return [self._doc_to_suggestion(d) for d in docs]
+        except Exception as e:
+            logger.error("DB find failed: %s", e)
+            raise DatabaseError(f"Failed to list suggestions: {e}") from e
+
+    async def set_message(self, sugg_id: int, message_id: str) -> None:
+        try:
+            await self._col().update_one({"id": sugg_id}, {"$set": {"message_id": message_id}})
+        except Exception as e:
+            logger.error("DB update_one failed: %s", e)
+            raise DatabaseError(f"Failed to set suggestion message id: {e}") from e
+
+    async def update_status(
+        self,
+        sugg_id: int,
+        status: SuggestionStatus,
+        reason: str | None,
+        decided_by: str,
+    ) -> None:
+        try:
+            await self._col().update_one(
+                {"id": sugg_id},
+                {
+                    "$set": {
+                        "status": status,
+                        "reason": reason,
+                        "decided_by": decided_by,
+                        "decided_at": datetime.now(),
+                    }
+                },
+            )
+        except Exception as e:
+            logger.error("DB update_one failed: %s", e)
+            raise DatabaseError(f"Failed to update suggestion status: {e}") from e
+
+    async def set_vote(self, sugg_id: int, user_id: str, direction: str) -> Suggestion | None:
+        """Set/replace a user's vote. Returns the updated suggestion."""
+        try:
+            doc = await self._col().find_one_and_update(
+                {"id": sugg_id},
+                {"$set": {f"votes.{user_id}": direction}},
+                return_document=ReturnDocument.AFTER,
+            )
+            return self._doc_to_suggestion(doc) if doc else None
+        except Exception as e:
+            logger.error("DB set_vote failed: %s", e)
+            raise DatabaseError(f"Failed to set vote: {e}") from e
+
+    async def remove_vote(self, sugg_id: int, user_id: str) -> Suggestion | None:
+        try:
+            doc = await self._col().find_one_and_update(
+                {"id": sugg_id},
+                {"$unset": {f"votes.{user_id}": ""}},
+                return_document=ReturnDocument.AFTER,
+            )
+            return self._doc_to_suggestion(doc) if doc else None
+        except Exception as e:
+            logger.error("DB remove_vote failed: %s", e)
+            raise DatabaseError(f"Failed to remove vote: {e}") from e

--- a/src/webui/app.py
+++ b/src/webui/app.py
@@ -30,6 +30,9 @@ from src.webui.routes import (
     frontend as frontend_routes,
 )
 from src.webui.routes import (
+    rolemenus as rolemenus_routes,
+)
+from src.webui.routes import (
     servers as servers_routes,
 )
 from src.webui.sse import logs as logs_sse
@@ -74,6 +77,7 @@ def create_app(bot=None, bot_loop=None) -> FastAPI:
     app.include_router(auth_routes.create_router(ctx))
     app.include_router(config_routes.create_router(ctx))
     app.include_router(servers_routes.create_router(ctx))
+    app.include_router(rolemenus_routes.create_router(ctx))
     app.include_router(extensions_routes.create_router(ctx))
     app.include_router(bot_routes.create_router(ctx))
     app.include_router(logs_sse.create_router(ctx))

--- a/src/webui/routes/rolemenus.py
+++ b/src/webui/routes/rolemenus.py
@@ -1,0 +1,317 @@
+"""Reaction-role menu CRUD endpoints.
+
+The WebUI builder calls these to create / edit / delete role menus on a guild.
+Each mutation persists in MongoDB **and** posts/edits/deletes the actual
+Discord message via the bot client, so the menu stays in sync with what
+``/rolemenu`` would produce.
+"""
+
+import asyncio
+from datetime import datetime
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+
+from features.reactionroles import ReactionRolesRepository, RoleMenu, RoleMenuEntry
+from src.core import logging as logutil
+from src.webui.context import WebUIContext
+
+logger = logutil.init_logger("webui.routes.rolemenus")
+
+
+# ── Request models ──────────────────────────────────────────────────
+
+
+class RoleMenuEntryIn(BaseModel):
+    role_id: str
+    emoji: str
+    label: str
+
+
+class RoleMenuCreate(BaseModel):
+    channel_id: str
+    title: str = Field(min_length=1, max_length=256)
+    description: str | None = None
+    entries: list[RoleMenuEntryIn]
+
+
+class RoleMenuUpdate(BaseModel):
+    title: str | None = Field(default=None, min_length=1, max_length=256)
+    description: str | None = None
+    entries: list[RoleMenuEntryIn] | None = None
+
+
+# ── Helpers ─────────────────────────────────────────────────────────
+
+
+def _menu_to_dict(menu: RoleMenu) -> dict:
+    return {
+        "id": menu.id,
+        "guild_id": menu.guild_id,
+        "channel_id": menu.channel_id,
+        "message_id": menu.message_id,
+        "title": menu.title,
+        "description": menu.description,
+        "entries": [e.model_dump() for e in menu.entries],
+        "created_by": menu.created_by,
+        "created_at": menu.created_at.isoformat() if menu.created_at else None,
+    }
+
+
+def _validate_entries(
+    entries_in: list[RoleMenuEntryIn], guild_role_ids: set[str]
+) -> list[RoleMenuEntry] | str:
+    from extensions.reactionroles._common import MAX_ENTRIES
+
+    if not entries_in:
+        return "Au moins une entrée requise."
+    if len(entries_in) > MAX_ENTRIES:
+        return f"Maximum {MAX_ENTRIES} entrées par menu (limite Discord)."
+    out: list[RoleMenuEntry] = []
+    for idx, e in enumerate(entries_in, 1):
+        if not e.role_id.isdigit():
+            return f"Entrée {idx} : role_id doit être numérique."
+        if e.role_id not in guild_role_ids:
+            return f"Entrée {idx} : rôle <@&{e.role_id}> introuvable."
+        if not e.emoji:
+            return f"Entrée {idx} : emoji manquant."
+        if not e.label.strip():
+            return f"Entrée {idx} : libellé manquant."
+        if len(e.label) > 80:
+            return f"Entrée {idx} : libellé trop long (max 80)."
+        out.append(RoleMenuEntry(role_id=e.role_id, emoji=e.emoji, label=e.label))
+    return out
+
+
+async def _resolve_guild_and_channel(bot, guild_id: str, channel_id: str):
+    try:
+        guild = await bot.fetch_guild(int(guild_id))
+    except Exception as e:
+        raise HTTPException(status_code=404, detail=f"Serveur introuvable: {e}") from e
+    if guild is None:
+        raise HTTPException(status_code=404, detail="Serveur introuvable")
+    try:
+        channel = await bot.fetch_channel(int(channel_id))
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"Salon introuvable: {e}") from e
+    if channel is None or not hasattr(channel, "send"):
+        raise HTTPException(status_code=400, detail="Salon invalide ou non accessible")
+    return guild, channel
+
+
+def _run_on_bot_loop(ctx: WebUIContext, coro):
+    if not ctx.bot or not ctx.bot_loop:
+        raise HTTPException(status_code=503, detail="Bot non disponible")
+    future = asyncio.run_coroutine_threadsafe(coro, ctx.bot_loop)
+    return asyncio.wrap_future(future)
+
+
+# ── Router factory ──────────────────────────────────────────────────
+
+
+def create_router(ctx: WebUIContext) -> APIRouter:
+    router = APIRouter()
+
+    @router.get("/api/servers/{server_id}/roles")
+    async def api_list_roles(request: Request, server_id: str):
+        """List assignable roles in a guild (for the role-picker)."""
+        ctx.require_admin(request)
+
+        async def _fetch():
+            try:
+                guild = await ctx.bot.fetch_guild(int(server_id))
+            except Exception as e:
+                raise HTTPException(status_code=404, detail=f"Serveur introuvable: {e}") from e
+            if guild is None:
+                raise HTTPException(status_code=404, detail="Serveur introuvable")
+            roles = []
+            for r in getattr(guild, "roles", []) or []:
+                # Skip @everyone (id == guild.id) and managed/integration roles.
+                if str(r.id) == str(guild.id):
+                    continue
+                if getattr(r, "managed", False):
+                    continue
+                color = getattr(r, "color", None)
+                color_hex = None
+                if color is not None:
+                    try:
+                        color_hex = f"#{int(color):06x}"
+                    except Exception:
+                        color_hex = None
+                roles.append(
+                    {
+                        "id": str(r.id),
+                        "name": getattr(r, "name", str(r.id)),
+                        "position": getattr(r, "position", 0) or 0,
+                        "color": color_hex,
+                    }
+                )
+            roles.sort(key=lambda x: -x["position"])  # higher position first
+            return {"roles": roles}
+
+        try:
+            data = await _run_on_bot_loop(ctx, _fetch())
+        except HTTPException:
+            raise
+        except Exception as e:
+            logger.error("List roles failed for %s: %s", server_id, e)
+            raise HTTPException(status_code=500, detail=str(e)) from e
+        return JSONResponse(data)
+
+    @router.get("/api/servers/{server_id}/rolemenus")
+    async def api_list_rolemenus(request: Request, server_id: str):
+        ctx.require_admin(request)
+        repo = ReactionRolesRepository(server_id)
+        try:
+            menus = await repo.list()
+        except Exception as e:
+            logger.error("List rolemenus failed for %s: %s", server_id, e)
+            raise HTTPException(status_code=500, detail=str(e)) from e
+        return JSONResponse({"menus": [_menu_to_dict(m) for m in menus]})
+
+    @router.post("/api/servers/{server_id}/rolemenus")
+    async def api_create_rolemenu(request: Request, server_id: str, body: RoleMenuCreate):
+        session = ctx.require_admin(request)
+
+        async def _create():
+            from extensions.reactionroles._common import build_components, build_embed
+
+            guild, channel = await _resolve_guild_and_channel(ctx.bot, server_id, body.channel_id)
+            guild_role_ids = {str(r.id) for r in getattr(guild, "roles", []) or []}
+            parsed = _validate_entries(body.entries, guild_role_ids)
+            if isinstance(parsed, str):
+                raise HTTPException(status_code=400, detail=parsed)
+
+            repo = ReactionRolesRepository(server_id)
+            menu = RoleMenu(
+                guild_id=str(server_id),
+                channel_id=str(channel.id),
+                title=body.title,
+                description=body.description,
+                entries=parsed,
+                created_by=str(getattr(session, "user_id", "webui")),
+                created_at=datetime.now(),
+            )
+            menu_id = await repo.add(menu)
+
+            embed = build_embed(body.title, body.description, parsed)
+            components = build_components(menu_id, parsed)
+            try:
+                sent = await channel.send(embeds=[embed], components=components)
+            except Exception as e:
+                await repo.delete(menu_id)
+                raise HTTPException(
+                    status_code=500, detail=f"Échec de l'envoi du menu : {e}"
+                ) from e
+            await repo.update(menu_id, message_id=str(sent.id))
+            menu.id = menu_id
+            menu.message_id = str(sent.id)
+            return menu
+
+        try:
+            menu = await _run_on_bot_loop(ctx, _create())
+        except HTTPException:
+            raise
+        except Exception as e:
+            logger.error("Create rolemenu failed for %s: %s", server_id, e)
+            raise HTTPException(status_code=500, detail=str(e)) from e
+        logger.info("Rolemenu created via WebUI for guild %s", server_id)
+        return JSONResponse({"status": "ok", "menu": _menu_to_dict(menu)})
+
+    @router.put("/api/servers/{server_id}/rolemenus/{menu_id}")
+    async def api_update_rolemenu(
+        request: Request, server_id: str, menu_id: str, body: RoleMenuUpdate
+    ):
+        ctx.require_admin(request)
+
+        async def _update():
+            from extensions.reactionroles._common import build_components, build_embed
+
+            repo = ReactionRolesRepository(server_id)
+            existing = await repo.get(menu_id)
+            if not existing:
+                raise HTTPException(status_code=404, detail="Menu introuvable")
+
+            try:
+                guild = await ctx.bot.fetch_guild(int(server_id))
+            except Exception as e:
+                raise HTTPException(status_code=404, detail=f"Serveur introuvable: {e}") from e
+            guild_role_ids = {str(r.id) for r in getattr(guild, "roles", []) or []}
+
+            new_title = body.title if body.title is not None else existing.title
+            new_description = (
+                body.description if body.description is not None else existing.description
+            )
+            if body.entries is not None:
+                parsed = _validate_entries(body.entries, guild_role_ids)
+                if isinstance(parsed, str):
+                    raise HTTPException(status_code=400, detail=parsed)
+                new_entries = parsed
+            else:
+                new_entries = existing.entries
+
+            await repo.update(
+                menu_id,
+                title=new_title,
+                description=new_description,
+                entries=[e.model_dump() for e in new_entries],
+            )
+
+            if existing.message_id:
+                try:
+                    channel = await ctx.bot.fetch_channel(int(existing.channel_id))
+                    if channel and hasattr(channel, "fetch_message"):
+                        msg = await channel.fetch_message(int(existing.message_id))
+                        if msg:
+                            embed = build_embed(new_title, new_description, new_entries)
+                            components = build_components(menu_id, new_entries)
+                            await msg.edit(embeds=[embed], components=components)
+                except Exception as e:
+                    logger.warning("Could not edit role menu message %s: %s", menu_id, e)
+
+            updated = await repo.get(menu_id)
+            return updated
+
+        try:
+            menu = await _run_on_bot_loop(ctx, _update())
+        except HTTPException:
+            raise
+        except Exception as e:
+            logger.error("Update rolemenu failed for %s/%s: %s", server_id, menu_id, e)
+            raise HTTPException(status_code=500, detail=str(e)) from e
+        logger.info("Rolemenu %s updated via WebUI for guild %s", menu_id, server_id)
+        return JSONResponse({"status": "ok", "menu": _menu_to_dict(menu) if menu else None})
+
+    @router.delete("/api/servers/{server_id}/rolemenus/{menu_id}")
+    async def api_delete_rolemenu(request: Request, server_id: str, menu_id: str):
+        ctx.require_admin(request)
+
+        async def _delete():
+            repo = ReactionRolesRepository(server_id)
+            existing = await repo.get(menu_id)
+            if not existing:
+                raise HTTPException(status_code=404, detail="Menu introuvable")
+
+            await repo.delete(menu_id)
+            if existing.message_id:
+                try:
+                    channel = await ctx.bot.fetch_channel(int(existing.channel_id))
+                    if channel and hasattr(channel, "fetch_message"):
+                        msg = await channel.fetch_message(int(existing.message_id))
+                        if msg:
+                            await msg.delete()
+                except Exception as e:
+                    logger.warning("Could not delete role menu message %s: %s", menu_id, e)
+
+        try:
+            await _run_on_bot_loop(ctx, _delete())
+        except HTTPException:
+            raise
+        except Exception as e:
+            logger.error("Delete rolemenu failed for %s/%s: %s", server_id, menu_id, e)
+            raise HTTPException(status_code=500, detail=str(e)) from e
+        logger.info("Rolemenu %s deleted via WebUI for guild %s", menu_id, server_id)
+        return JSONResponse({"status": "ok"})
+
+    return router

--- a/src/webui/routes/rolemenus.py
+++ b/src/webui/routes/rolemenus.py
@@ -13,7 +13,14 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
-from features.reactionroles import ReactionRolesRepository, RoleMenu, RoleMenuEntry
+from features.reactionroles import (
+    MAX_ENTRIES,
+    ReactionRolesRepository,
+    RoleMenu,
+    RoleMenuEntry,
+    build_components,
+    build_embed,
+)
 from src.core import logging as logutil
 from src.webui.context import WebUIContext
 
@@ -62,8 +69,6 @@ def _menu_to_dict(menu: RoleMenu) -> dict:
 def _validate_entries(
     entries_in: list[RoleMenuEntryIn], guild_role_ids: set[str]
 ) -> list[RoleMenuEntry] | str:
-    from extensions.reactionroles._common import MAX_ENTRIES
-
     if not entries_in:
         return "Au moins une entrée requise."
     if len(entries_in) > MAX_ENTRIES:
@@ -175,8 +180,6 @@ def create_router(ctx: WebUIContext) -> APIRouter:
         session = ctx.require_admin(request)
 
         async def _create():
-            from extensions.reactionroles._common import build_components, build_embed
-
             guild, channel = await _resolve_guild_and_channel(ctx.bot, server_id, body.channel_id)
             guild_role_ids = {str(r.id) for r in getattr(guild, "roles", []) or []}
             parsed = _validate_entries(body.entries, guild_role_ids)
@@ -226,8 +229,6 @@ def create_router(ctx: WebUIContext) -> APIRouter:
         ctx.require_admin(request)
 
         async def _update():
-            from extensions.reactionroles._common import build_components, build_embed
-
             repo = ReactionRolesRepository(server_id)
             existing = await repo.get(menu_id)
             if not existing:

--- a/src/webui/static/index.html
+++ b/src/webui/static/index.html
@@ -4102,6 +4102,10 @@
             populateChannelPickers(document);
             populateMemberPickers(document);
         }
+        // Reaction-roles builder: load existing menus when on its module page.
+        if (state.currentPage === 'module' && state.currentModule === 'moduleReactionRoles' && state.currentServerId) {
+            loadRoleMenus(state.currentServerId);
+        }
     }
 
     function renderLogin() {
@@ -4916,6 +4920,11 @@
                             📢 Publier
                         </button>
                         ` : ''}
+                        ${mod === 'moduleReactionRoles' ? `
+                        <button class="btn btn-primary btn-sm" onclick="openRoleMenuBuilder('${sid}', null)">
+                            ✨ Nouveau menu
+                        </button>
+                        ` : ''}
                     </div>
                 </div>
                 ${schema
@@ -4932,6 +4941,32 @@
                 }
             </div>
 
+            ${mod === 'moduleReactionRoles' ? `
+            <div class="card" style="margin-top:16px;">
+                <div class="card-header">
+                    <div>
+                        <div class="card-title">Menus de rôles</div>
+                        <div class="card-subtitle">Boutons que les membres cliquent pour s'auto-attribuer un rôle.</div>
+                    </div>
+                </div>
+                <div id="rolemenu-list" data-server-id="${sid}">
+                    <div class="loading"><div class="spinner"></div></div>
+                </div>
+            </div>
+            <div class="card" id="rolemenu-builder-card" data-server-id="${sid}" style="margin-top:16px; display:none;">
+                <div class="card-header">
+                    <div>
+                        <div class="card-title" id="rolemenu-builder-title">Nouveau menu</div>
+                        <div class="card-subtitle">Le menu est posté immédiatement dans le salon choisi.</div>
+                    </div>
+                    <div class="card-actions">
+                        <button class="btn btn-ghost btn-sm" onclick="closeRoleMenuBuilder()">Annuler</button>
+                        <button class="btn btn-success btn-sm" onclick="saveRoleMenu()">💾 Enregistrer</button>
+                    </div>
+                </div>
+                <div id="rolemenu-builder-body"></div>
+            </div>
+            ` : ''}
             ${schema && !schema.directValue ? renderExtraKeysCard(schema, modConfig) : ''}
         `;
     }
@@ -5108,6 +5143,241 @@
         try {
             const result = await api(`/api/servers/${serverId}/modules/moduleEmbedManager/publish`, { method: 'POST' });
             toast(`✓ ${result.count} embed(s) publié(s) avec succès`, 'success');
+        } catch (e) { /* handled by api() */ }
+    }
+
+    // ── Reaction Roles builder ────────────────────────
+    const _rolesCache = {}; // serverId -> [{id, name, color, position}]
+    let _rolemenuEditing = null;  // null = create, otherwise menu id being edited
+
+    async function fetchServerRoles(serverId) {
+        if (!serverId) return [];
+        if (_rolesCache[serverId]) return _rolesCache[serverId];
+        try {
+            const data = await api(`/api/servers/${serverId}/roles`);
+            const roles = data?.roles || [];
+            _rolesCache[serverId] = roles;
+            return roles;
+        } catch (e) {
+            console.warn('Could not fetch roles', e);
+            return [];
+        }
+    }
+
+    async function loadRoleMenus(serverId) {
+        const container = document.getElementById('rolemenu-list');
+        if (!container) return;
+        try {
+            const data = await api(`/api/servers/${serverId}/rolemenus`);
+            const menus = data?.menus || [];
+            if (menus.length === 0) {
+                container.innerHTML = `<div class="empty-state"><h3>Aucun menu</h3><p>Cliquez sur « Nouveau menu » pour en créer un.</p></div>`;
+                return;
+            }
+            container.innerHTML = menus.map(m => {
+                const jumpUrl = m.message_id
+                    ? `https://discord.com/channels/${m.guild_id}/${m.channel_id}/${m.message_id}`
+                    : null;
+                const entriesPreview = (m.entries || []).slice(0, 5).map(e =>
+                    `<span style="margin-right:8px;">${escapeHtml(e.emoji)} ${escapeHtml(e.label)}</span>`
+                ).join('');
+                const more = (m.entries?.length || 0) > 5 ? ` <span style="color:var(--text-muted)">+${m.entries.length - 5}</span>` : '';
+                return `
+                    <div style="border:1px solid var(--border); border-radius:var(--radius); padding:12px; margin-bottom:8px; display:flex; flex-direction:column; gap:6px;">
+                        <div style="display:flex; align-items:center; justify-content:space-between; gap:8px; flex-wrap:wrap;">
+                            <div>
+                                <strong>${escapeHtml(m.title || '(sans titre)')}</strong>
+                                <span style="color:var(--text-muted); margin-left:8px;">&lt;#${escapeHtml(m.channel_id)}&gt;</span>
+                                ${jumpUrl ? `<a href="${jumpUrl}" target="_blank" style="margin-left:8px;">↗ Discord</a>` : ''}
+                            </div>
+                            <div style="display:flex; gap:6px;">
+                                <button class="btn btn-ghost btn-sm" onclick="openRoleMenuBuilder('${escapeHtml(serverId)}', '${escapeHtml(m.id)}')">✏️ Modifier</button>
+                                <button class="btn btn-ghost btn-sm" style="color:var(--danger)" onclick="deleteRoleMenu('${escapeHtml(serverId)}', '${escapeHtml(m.id)}')">🗑️ Supprimer</button>
+                            </div>
+                        </div>
+                        <div style="font-size:13px;">${entriesPreview}${more}</div>
+                    </div>
+                `;
+            }).join('');
+        } catch (e) {
+            container.innerHTML = `<div class="empty-state"><h3>Erreur</h3><p>${escapeHtml(String(e))}</p></div>`;
+        }
+    }
+
+    function _renderRoleSelect(roles, currentRoleId) {
+        let opts = '<option value="">— Choisir un rôle —</option>';
+        for (const r of roles) {
+            const sel = String(r.id) === String(currentRoleId) ? 'selected' : '';
+            opts += `<option value="${escapeHtml(r.id)}" ${sel}>@${escapeHtml(r.name)}</option>`;
+        }
+        return opts;
+    }
+
+    function _renderEntryRow(roles, entry) {
+        const e = entry || { role_id: '', emoji: '', label: '' };
+        return `
+            <div class="rolemenu-entry" style="display:grid; grid-template-columns: 1fr 80px 1fr 36px; gap:8px; align-items:center; margin-bottom:6px;">
+                <select class="form-input" data-rrf="role_id">${_renderRoleSelect(roles, e.role_id)}</select>
+                <input type="text" class="form-input" data-rrf="emoji" value="${escapeHtml(e.emoji)}" placeholder="🎮" maxlength="64">
+                <input type="text" class="form-input" data-rrf="label" value="${escapeHtml(e.label)}" placeholder="Libellé du bouton" maxlength="80">
+                <button type="button" class="btn-remove-entry" onclick="this.closest('.rolemenu-entry').remove()" title="Supprimer">✕</button>
+            </div>
+        `;
+    }
+
+    async function openRoleMenuBuilder(serverId, menuId) {
+        const card = document.getElementById('rolemenu-builder-card');
+        const body = document.getElementById('rolemenu-builder-body');
+        const titleEl = document.getElementById('rolemenu-builder-title');
+        if (!card || !body) return;
+        _rolemenuEditing = menuId || null;
+        titleEl.textContent = menuId ? 'Modifier le menu' : 'Nouveau menu';
+
+        body.innerHTML = `<div class="loading"><div class="spinner"></div></div>`;
+        card.style.display = 'block';
+        card.scrollIntoView({ behavior: 'smooth', block: 'start' });
+
+        const [roles, channelData, menus] = await Promise.all([
+            fetchServerRoles(serverId),
+            fetchServerChannels(serverId),
+            menuId ? api(`/api/servers/${serverId}/rolemenus`) : Promise.resolve(null),
+        ]);
+
+        let menu = null;
+        if (menuId && menus?.menus) {
+            menu = menus.menus.find(m => m.id === menuId);
+        }
+        const initial = menu || { channel_id: '', title: '', description: '', entries: [{}] };
+        if (!initial.entries || initial.entries.length === 0) initial.entries = [{}];
+
+        let channelOpts = '<option value="">— Choisir un salon —</option>';
+        if (channelData?.channels) {
+            const grouped = new Map();
+            for (const c of channelData.channels) {
+                if (c.is_thread) continue;
+                const catId = c.parent_id || '__none__';
+                if (!grouped.has(catId)) grouped.set(catId, []);
+                grouped.get(catId).push(c);
+            }
+            const orderedCats = [
+                ['__none__', 'Sans catégorie'],
+                ...((channelData.categories || []).map(c => [c.id, c.name])),
+            ];
+            for (const [catId, catName] of orderedCats) {
+                const list = grouped.get(catId);
+                if (!list || list.length === 0) continue;
+                channelOpts += `<optgroup label="${escapeHtml(catName)}">`;
+                for (const ch of list) {
+                    const sel = String(ch.id) === String(initial.channel_id) ? 'selected' : '';
+                    channelOpts += `<option value="${escapeHtml(ch.id)}" ${sel}>#${escapeHtml(ch.name)}</option>`;
+                }
+                channelOpts += `</optgroup>`;
+            }
+        }
+
+        body.innerHTML = `
+            <div class="form-grid" style="display:flex; flex-direction:column; gap:12px;">
+                <div>
+                    <label class="form-label">Salon</label>
+                    <select class="form-input" id="rrf-channel" ${menuId ? 'disabled title="Le salon est figé une fois le menu créé."' : ''}>
+                        ${channelOpts}
+                    </select>
+                </div>
+                <div>
+                    <label class="form-label">Titre</label>
+                    <input type="text" class="form-input" id="rrf-title" value="${escapeHtml(initial.title || '')}" maxlength="256" placeholder="Ex : Choisis tes rôles">
+                </div>
+                <div>
+                    <label class="form-label">Description (optionnel)</label>
+                    <textarea class="form-textarea" id="rrf-description" rows="2" placeholder="Affichée au-dessus de la liste des rôles">${escapeHtml(initial.description || '')}</textarea>
+                </div>
+                <div>
+                    <label class="form-label">Entrées (max 25)</label>
+                    <div id="rrf-entries">
+                        ${initial.entries.map(e => _renderEntryRow(roles, e)).join('')}
+                    </div>
+                    <button type="button" class="btn-add-entry" onclick="addRoleMenuEntry()">+ Ajouter une entrée</button>
+                </div>
+            </div>
+        `;
+    }
+
+    function addRoleMenuEntry() {
+        const list = document.getElementById('rrf-entries');
+        if (!list) return;
+        if (list.querySelectorAll('.rolemenu-entry').length >= 25) {
+            toast('Maximum 25 entrées par menu (limite Discord).', 'warning');
+            return;
+        }
+        const sid = state.currentServerId;
+        const roles = _rolesCache[sid] || [];
+        list.insertAdjacentHTML('beforeend', _renderEntryRow(roles, null));
+    }
+
+    function closeRoleMenuBuilder() {
+        const card = document.getElementById('rolemenu-builder-card');
+        if (card) card.style.display = 'none';
+        _rolemenuEditing = null;
+    }
+
+    function _collectRoleMenuPayload() {
+        const channel_id = document.getElementById('rrf-channel')?.value?.trim() || '';
+        const title = document.getElementById('rrf-title')?.value?.trim() || '';
+        const description = document.getElementById('rrf-description')?.value?.trim() || '';
+        const entries = [];
+        document.querySelectorAll('#rrf-entries .rolemenu-entry').forEach(row => {
+            const role_id = row.querySelector('[data-rrf="role_id"]')?.value?.trim() || '';
+            const emoji = row.querySelector('[data-rrf="emoji"]')?.value?.trim() || '';
+            const label = row.querySelector('[data-rrf="label"]')?.value?.trim() || '';
+            if (role_id || emoji || label) entries.push({ role_id, emoji, label });
+        });
+        return { channel_id, title, description: description || null, entries };
+    }
+
+    async function saveRoleMenu() {
+        const sid = state.currentServerId;
+        if (!sid) return;
+        const payload = _collectRoleMenuPayload();
+        if (!_rolemenuEditing && !payload.channel_id) return toast('Salon requis.', 'warning');
+        if (!payload.title) return toast('Titre requis.', 'warning');
+        if (!payload.entries.length) return toast('Au moins une entrée requise.', 'warning');
+        for (const [i, e] of payload.entries.entries()) {
+            if (!e.role_id) return toast(`Entrée ${i + 1} : rôle manquant.`, 'warning');
+            if (!e.emoji) return toast(`Entrée ${i + 1} : emoji manquant.`, 'warning');
+            if (!e.label) return toast(`Entrée ${i + 1} : libellé manquant.`, 'warning');
+        }
+
+        try {
+            if (_rolemenuEditing) {
+                const body = {
+                    title: payload.title,
+                    description: payload.description,
+                    entries: payload.entries,
+                };
+                await api(`/api/servers/${sid}/rolemenus/${_rolemenuEditing}`, {
+                    method: 'PUT',
+                    body: JSON.stringify(body),
+                });
+                toast('Menu mis à jour.', 'success');
+            } else {
+                await api(`/api/servers/${sid}/rolemenus`, {
+                    method: 'POST',
+                    body: JSON.stringify(payload),
+                });
+                toast('Menu créé.', 'success');
+            }
+            closeRoleMenuBuilder();
+            loadRoleMenus(sid);
+        } catch (e) { /* handled by api() */ }
+    }
+
+    async function deleteRoleMenu(serverId, menuId) {
+        if (!confirm('Supprimer ce menu ? Le message Discord associé sera également supprimé.')) return;
+        try {
+            await api(`/api/servers/${serverId}/rolemenus/${menuId}`, { method: 'DELETE' });
+            toast('Menu supprimé.', 'success');
+            if (_rolemenuEditing === menuId) closeRoleMenuBuilder();
+            loadRoleMenus(serverId);
         } catch (e) { /* handled by api() */ }
     }
 


### PR DESCRIPTION
## Summary

Trois extensions « classiques » manquantes pour serveurs communautaires, dans le style des extensions existantes (mixins, `features/` pour la persistance, config WebUI per-guild via `@register_module`).

- **Reaction Roles** (`extensions/reactionroles/`) — `/rolemenu create|list|delete|edit`. Boutons persistants qui ajoutent/retirent un rôle au clic. Jusqu'à 25 entrées par menu (5×5 = limite Discord). Stockage : `guild_<id>.role_menus`.
- **Suggestions** (`extensions/suggestions/`) — `/suggest <texte>` publie un embed dans le salon configuré avec votes 👍/👎 (boutons persistants, un vote par utilisateur, toggle off en re-cliquant). Sous-commandes staff `/suggestion approve|deny|implement` qui changent statut + couleur et désactivent le vote. IDs lisibles auto-incrémentés par serveur. Stockage : `guild_<id>.suggestions` + `suggestions_meta`.
- **Starboard** (`extensions/starboard/`) — listener sur `MessageReactionAdd/Remove`. Au seuil configuré, republie le message dans le salon starboard (auteur, contenu, image, lien d'origine, compteur). Met à jour le compteur en continu ; option `removeBelowThreshold` pour retirer le mirror si le seuil retombe. Filtre bots, salons ignorés, et auto-stars. Stockage : `guild_<id>.starboard` (clé = id du message original).

Aucun changement à `main.py` : auto-discovery des extensions. Tous les `custom_id` de boutons utilisent un préfixe stable + regex pour résister aux redémarrages.

Conventions respectées :
- `Extension + Mixin` pattern (cf. `extensions/spotify/`, `extensions/secretsanta/`)
- `features/<name>/{models.py,repository.py}` avec Pydantic + `mongo_manager.get_guild_collection`
- `@register_module(...)` dans `_common.py` pour intégration WebUI
- Texte utilisateur en français, palette `Colors`, `send_error`/`send_success`

## Test plan

- [ ] Activer `moduleReactionRoles` dans la config d'un serveur de test, redémarrer
- [ ] `/rolemenu create #salon "Choisis tes rôles" "111,🎮,Gamer;222,🎨,Artiste"` puis cliquer sur les boutons (toggle on/off)
- [ ] Redémarrer le bot, re-cliquer → toujours fonctionnel (callbacks persistants)
- [ ] `/rolemenu list` puis `/rolemenu delete <id>` → embed et doc supprimés
- [ ] Activer `moduleSuggestions` avec `suggestChannelId` + `staffRoleId` ; `/suggest "..."` → embed avec votes
- [ ] Cliquer 👍 puis 👎 (avec différents comptes) ; re-cliquer même côté → vote retiré
- [ ] `/suggestion approve|deny|implement id:1` (en tant que staff) → embed mis à jour, votes désactivés, auteur ping
- [ ] Activer `moduleStarboard` avec seuil 2, salon dédié ; obtenir 2 ⭐ sur un message → embed publié
- [ ] Ajouter un 3e ⭐ → compteur mis à jour (pas de doublon)
- [ ] Retirer des ⭐ sous le seuil avec `removeBelowThreshold=true` → mirror supprimé ; avec `false` → compteur seulement mis à jour
- [ ] Auto-star avec `allowSelfStar=false` → réaction de l'auteur non comptée

https://claude.ai/code/session_013hE3KALPQMDwjBpEvoyvg8

---
_Generated by [Claude Code](https://claude.ai/code/session_013hE3KALPQMDwjBpEvoyvg8)_