### PR TITLE
feat: extend admin, polls, reminders, twitch, tricount, xp, youtube, welcome

### DIFF
--- a/extensions/admin/__init__.py
+++ b/extensions/admin/__init__.py
@@ -4,6 +4,9 @@ Slash commands:
 - ``/ping`` — bot latency probe
 - ``/delete`` — bulk-delete messages in a channel
 - ``/send`` — send a message to a channel as the bot
+- ``/slowmode`` — set or clear a channel's slowmode delay
+- ``/lock`` — deny @everyone send permissions on a channel
+- ``/unlock`` — restore @everyone send permissions on a channel
 
 Enablement is shared with :mod:`extensions.polls` and
 :mod:`extensions.reminders` via the ``moduleUtils`` config key. This package
@@ -30,7 +33,7 @@ from interactions import (
 
 from src.core import logging as logutil
 from src.core.config import load_config
-from src.discord_ext.messages import send_error
+from src.discord_ext.messages import send_error, send_success
 from src.webui.schemas import SchemaBase, enabled_field, register_module
 
 
@@ -165,6 +168,160 @@ class AdminExtension(Extension):
             sent.channel.id,
         )
         await ctx.send("Message envoyé !", ephemeral=True)
+
+
+    @slash_command(
+        name="slowmode",
+        description="Définir le mode lent d'un salon (0 = désactivé)",
+        scopes=enabled_servers_int,  # type: ignore
+    )
+    @slash_option(
+        "secondes",
+        "Délai en secondes entre messages (0–21600)",
+        opt_type=OptionType.INTEGER,
+        required=True,
+        min_value=0,
+        max_value=21600,
+    )
+    @slash_option(
+        "channel",
+        "Salon ciblé (par défaut : salon courant)",
+        opt_type=OptionType.CHANNEL,
+        required=False,
+        channel_types=[
+            ChannelType.GUILD_TEXT,
+            ChannelType.GUILD_NEWS,
+            ChannelType.GUILD_PUBLIC_THREAD,
+            ChannelType.GUILD_PRIVATE_THREAD,
+            ChannelType.GUILD_NEWS_THREAD,
+        ],
+    )
+    @slash_default_member_permission(Permissions.MANAGE_CHANNELS)
+    async def slowmode(
+        self,
+        ctx: SlashContext,
+        secondes: int,
+        channel: BaseChannel | None = None,
+    ):
+        target = channel or ctx.channel
+        try:
+            await target.edit(
+                rate_limit_per_user=secondes,
+                reason=f"Slowmode défini par {ctx.user.username} (ID: {ctx.user.id})",
+            )
+        except Exception as e:
+            await send_error(ctx, f"Impossible de modifier le salon : {e}")
+            return
+
+        if secondes == 0:
+            await send_success(ctx, f"Mode lent désactivé sur <#{target.id}>.")
+        else:
+            await send_success(
+                ctx, f"Mode lent réglé à **{secondes}s** sur <#{target.id}>."
+            )
+        logger.info(
+            "Slowmode set to %ss on #%s by %s (ID: %s)",
+            secondes,
+            target.name,
+            ctx.user.username,
+            ctx.user.id,
+        )
+
+    @slash_command(
+        name="lock",
+        description="Verrouiller un salon (empêcher @everyone d'écrire)",
+        scopes=enabled_servers_int,  # type: ignore
+    )
+    @slash_option(
+        "channel",
+        "Salon à verrouiller (par défaut : salon courant)",
+        opt_type=OptionType.CHANNEL,
+        required=False,
+        channel_types=[ChannelType.GUILD_TEXT, ChannelType.GUILD_NEWS],
+    )
+    @slash_option(
+        "raison",
+        "Raison du verrouillage",
+        opt_type=OptionType.STRING,
+        required=False,
+    )
+    @slash_default_member_permission(Permissions.MANAGE_CHANNELS)
+    async def lock(
+        self,
+        ctx: SlashContext,
+        channel: BaseChannel | None = None,
+        raison: str | None = None,
+    ):
+        target = channel or ctx.channel
+        if not ctx.guild:
+            await send_error(ctx, "Cette commande ne peut être utilisée que dans un serveur.")
+            return
+        everyone = ctx.guild.default_role
+        try:
+            await target.add_permission(
+                everyone,
+                deny=Permissions.SEND_MESSAGES
+                | Permissions.SEND_MESSAGES_IN_THREADS
+                | Permissions.CREATE_PUBLIC_THREADS
+                | Permissions.CREATE_PRIVATE_THREADS,
+                reason=raison
+                or f"Verrouillé par {ctx.user.username} (ID: {ctx.user.id})",
+            )
+        except Exception as e:
+            await send_error(ctx, f"Impossible de verrouiller le salon : {e}")
+            return
+
+        suffix = f" — {raison}" if raison else ""
+        await send_success(ctx, f"🔒 <#{target.id}> verrouillé{suffix}.")
+        logger.info(
+            "Channel #%s locked by %s (ID: %s)%s",
+            target.name,
+            ctx.user.username,
+            ctx.user.id,
+            f" — {raison}" if raison else "",
+        )
+
+    @slash_command(
+        name="unlock",
+        description="Déverrouiller un salon précédemment verrouillé",
+        scopes=enabled_servers_int,  # type: ignore
+    )
+    @slash_option(
+        "channel",
+        "Salon à déverrouiller (par défaut : salon courant)",
+        opt_type=OptionType.CHANNEL,
+        required=False,
+        channel_types=[ChannelType.GUILD_TEXT, ChannelType.GUILD_NEWS],
+    )
+    @slash_default_member_permission(Permissions.MANAGE_CHANNELS)
+    async def unlock(
+        self,
+        ctx: SlashContext,
+        channel: BaseChannel | None = None,
+    ):
+        target = channel or ctx.channel
+        if not ctx.guild:
+            await send_error(ctx, "Cette commande ne peut être utilisée que dans un serveur.")
+            return
+        everyone = ctx.guild.default_role
+        try:
+            # Clear the deny mask we set in /lock by passing an empty Permissions flag.
+            await target.add_permission(
+                everyone,
+                deny=Permissions(0),
+                reason=f"Déverrouillé par {ctx.user.username} (ID: {ctx.user.id})",
+            )
+        except Exception as e:
+            await send_error(ctx, f"Impossible de déverrouiller le salon : {e}")
+            return
+
+        await send_success(ctx, f"🔓 <#{target.id}> déverrouillé.")
+        logger.info(
+            "Channel #%s unlocked by %s (ID: %s)",
+            target.name,
+            ctx.user.username,
+            ctx.user.id,
+        )
 
 
 def setup(bot: Client) -> None:

--- a/extensions/admin/__init__.py
+++ b/extensions/admin/__init__.py
@@ -34,7 +34,7 @@ from interactions import (
 from src.core import logging as logutil
 from src.core.config import load_config
 from src.discord_ext.messages import send_error, send_success
-from src.webui.schemas import SchemaBase, enabled_field, register_module
+from src.webui.schemas import SchemaBase, enabled_field, register_module, ui
 
 
 @register_module("moduleUtils")
@@ -45,6 +45,25 @@ class UtilsConfig(SchemaBase):
     __category__ = "Outils"
 
     enabled: bool = enabled_field()
+    reminderSnoozeMinutes: int = ui(
+        "Durée du snooze (rappels)",
+        "number",
+        default=10,
+        description=(
+            "Délai en minutes appliqué quand un membre clique sur le bouton "
+            "« Snooze » d'un rappel reçu en message privé."
+        ),
+    )
+    pollDefaultDurationMinutes: int = ui(
+        "Durée par défaut des sondages",
+        "number",
+        default=0,
+        description=(
+            "Si > 0, les commandes /poll, /poll-anonyme et /poll-classement "
+            "appliquent cette fermeture automatique quand l'option `duree` "
+            "n'est pas fournie."
+        ),
+    )
 
 
 logger = logutil.init_logger(os.path.basename(__file__))
@@ -169,7 +188,6 @@ class AdminExtension(Extension):
         )
         await ctx.send("Message envoyé !", ephemeral=True)
 
-
     @slash_command(
         name="slowmode",
         description="Définir le mode lent d'un salon (0 = désactivé)",
@@ -216,9 +234,7 @@ class AdminExtension(Extension):
         if secondes == 0:
             await send_success(ctx, f"Mode lent désactivé sur <#{target.id}>.")
         else:
-            await send_success(
-                ctx, f"Mode lent réglé à **{secondes}s** sur <#{target.id}>."
-            )
+            await send_success(ctx, f"Mode lent réglé à **{secondes}s** sur <#{target.id}>.")
         logger.info(
             "Slowmode set to %ss on #%s by %s (ID: %s)",
             secondes,
@@ -264,8 +280,7 @@ class AdminExtension(Extension):
                 | Permissions.SEND_MESSAGES_IN_THREADS
                 | Permissions.CREATE_PUBLIC_THREADS
                 | Permissions.CREATE_PRIVATE_THREADS,
-                reason=raison
-                or f"Verrouillé par {ctx.user.username} (ID: {ctx.user.id})",
+                reason=raison or f"Verrouillé par {ctx.user.username} (ID: {ctx.user.id})",
             )
         except Exception as e:
             await send_error(ctx, f"Impossible de verrouiller le salon : {e}")

--- a/extensions/polls/__init__.py
+++ b/extensions/polls/__init__.py
@@ -51,8 +51,22 @@ from src.discord_ext.paginator import format_poll
 from .buttons import PollButtonsMixin, render_results_field, update_poll_embed, vote_components
 
 logger = logutil.init_logger(os.path.basename(__file__))
-_, _, enabled_servers = load_config("moduleUtils")
+_, _utils_module_config, enabled_servers = load_config("moduleUtils")
 enabled_servers_int = [int(s) for s in enabled_servers]  # type: ignore[misc]
+
+
+def _default_poll_seconds(guild_id: str | int | None) -> int | None:
+    """Per-guild default auto-close (seconds) when ``duree`` is omitted; None disables it."""
+    if guild_id is None:
+        return None
+    cfg = _utils_module_config.get(str(guild_id), {})
+    minutes = cfg.get("pollDefaultDurationMinutes")
+    try:
+        value = int(minutes) if minutes is not None else 0
+    except (TypeError, ValueError):
+        value = 0
+    return value * 60 if value > 0 else None
+
 
 # In-memory map of (guild_id, message_id) → asyncio.Task that auto-closes
 # reaction-based polls. Button polls use the periodic task below instead.
@@ -141,6 +155,8 @@ class PollsExtension(Extension, PollButtonsMixin):
                     ctx, "Format de durée invalide. Utilisez par ex. `30m`, `2h`, `1d`."
                 )
                 return
+        else:
+            close_seconds = _default_poll_seconds(ctx.guild_id)
         description = "\n\n".join([f"{emojis[i]} {option}" for i, option in enumerate(options)])
         if close_seconds:
             close_time = datetime.now() + timedelta(seconds=close_seconds)
@@ -155,9 +171,7 @@ class PollsExtension(Extension, PollButtonsMixin):
         message = await ctx.send(embed=embed)
         await _add_poll_reactions(message, options, use_default=(options == DEFAULT_POLL_OPTIONS))
         if close_seconds:
-            self._schedule_reaction_close(
-                ctx.guild_id, message, close_seconds, options, emojis
-            )
+            self._schedule_reaction_close(ctx.guild_id, message, close_seconds, options, emojis)
         logger.debug(
             "Création d'un sondage par %s (ID: %s)\nQuestion : %s\nOptions : %s",
             ctx.user.username,
@@ -281,6 +295,7 @@ class PollsExtension(Extension, PollButtonsMixin):
             return
 
         closes_at: datetime | None = None
+        seconds: int | None = None
         if duration:
             seconds = parse_duration(duration)
             if seconds is None:
@@ -288,17 +303,16 @@ class PollsExtension(Extension, PollButtonsMixin):
                     ctx, "Format de durée invalide. Utilisez par ex. `30m`, `2h`, `1d`."
                 )
                 return
+        else:
+            seconds = _default_poll_seconds(ctx.guild_id)
+        if seconds:
             closes_at = datetime.now() + timedelta(seconds=seconds)
 
         mode_label = "anonyme" if mode == "anonymous" else "classement"
         embed = Embed(
             title=f"📊 {question}",
             description=f"*Sondage {mode_label}* — cliquez sur un bouton pour voter."
-            + (
-                f"\nFermeture : {format_discord_timestamp(closes_at, 'R')}"
-                if closes_at
-                else ""
-            ),
+            + (f"\nFermeture : {format_discord_timestamp(closes_at, 'R')}" if closes_at else ""),
             color=Colors.UTIL,
         )
         embed.set_footer(
@@ -342,9 +356,7 @@ class PollsExtension(Extension, PollButtonsMixin):
             channel = await self.bot.fetch_channel(int(poll.channel_id))
             message = await channel.fetch_message(int(poll.message_id))
         except Exception as e:
-            logger.warning(
-                "Could not fetch poll %s in channel %s: %s", poll.id, poll.channel_id, e
-            )
+            logger.warning("Could not fetch poll %s in channel %s: %s", poll.id, poll.channel_id, e)
             await self._poll_repo(guild_id).mark_closed(poll.id)
             return
 

--- a/extensions/polls/__init__.py
+++ b/extensions/polls/__init__.py
@@ -1,23 +1,31 @@
 """Polls Discord extension — poll creation, editing, and reaction tracking.
 
 Slash commands:
-- ``/poll`` — create a poll with up to 10 options
+- ``/poll`` — reaction-based poll, up to 10 options, optional auto-close
+- ``/poll-anonyme`` — button-based poll where voter identities aren't shown
+- ``/poll-classement`` — ranked-choice (instant-runoff) poll
 - ``/editpoll`` — edit the question, options, or reset reactions of a poll you created
 
 Listens to :class:`MessageReactionAdd` / :class:`MessageReactionRemove` to keep
-poll embeds' vote counts fresh. Enabled per-guild via ``moduleUtils``.
+reaction-based poll embeds' vote counts fresh. Button-based polls persist their
+state in MongoDB (``polls`` collection) and close automatically once their
+``closes_at`` deadline elapses. Enabled per-guild via ``moduleUtils``.
 """
 
 import asyncio
+import contextlib
 import os
+from datetime import datetime, timedelta
 
 from interactions import (
     Client,
     Embed,
     Extension,
     IntegrationType,
+    IntervalTrigger,
     OptionType,
     SlashContext,
+    Task,
     listen,
     slash_command,
     slash_option,
@@ -28,18 +36,27 @@ from features.polls import (
     DEFAULT_POLL_EMOJIS,
     DEFAULT_POLL_OPTIONS,
     POLL_EMOJIS,
+    Poll,
+    PollRepository,
+    parse_duration,
     parse_poll_author_id,
     validate_poll_options,
 )
 from src.core import logging as logutil
 from src.core.config import load_config
-from src.discord_ext.embeds import Colors
+from src.discord_ext.embeds import Colors, format_discord_timestamp
 from src.discord_ext.messages import send_error
 from src.discord_ext.paginator import format_poll
+
+from .buttons import PollButtonsMixin, render_results_field, update_poll_embed, vote_components
 
 logger = logutil.init_logger(os.path.basename(__file__))
 _, _, enabled_servers = load_config("moduleUtils")
 enabled_servers_int = [int(s) for s in enabled_servers]  # type: ignore[misc]
+
+# In-memory map of (guild_id, message_id) → asyncio.Task that auto-closes
+# reaction-based polls. Button polls use the periodic task below instead.
+_reaction_close_tasks: dict[tuple[str, str], asyncio.Task] = {}
 
 
 def _is_poll_embed(embed: Embed) -> bool:
@@ -52,10 +69,28 @@ async def _add_poll_reactions(message, options: list[str], use_default: bool = F
         await message.add_reaction(emojis[i])
 
 
-class PollsExtension(Extension):
+class PollsExtension(Extension, PollButtonsMixin):
     def __init__(self, bot: Client):
         self.bot = bot
         self.lock = asyncio.Lock()
+        self._poll_repos: dict[str, PollRepository] = {}
+
+    def _poll_repo(self, guild_id: str | int) -> PollRepository:
+        gid = str(guild_id)
+        repo = self._poll_repos.get(gid)
+        if repo is None:
+            repo = PollRepository(gid)
+            self._poll_repos[gid] = repo
+        return repo
+
+    @listen()
+    async def on_startup(self) -> None:
+        for guild_id in enabled_servers:
+            try:
+                await self._poll_repo(guild_id).ensure_indexes()
+            except Exception as e:
+                logger.error("Could not init poll indexes for %s: %s", guild_id, e)
+        self.check_closing_polls.start()
 
     @slash_command(
         name="poll",
@@ -75,7 +110,20 @@ class PollsExtension(Extension):
         opt_type=OptionType.STRING,
         required=False,
     )
-    async def poll(self, ctx: SlashContext, question, options=None):
+    @slash_option(
+        "duree",
+        "Fermeture automatique après ce délai (ex: 30m, 2h, 1d)",
+        opt_type=OptionType.STRING,
+        required=False,
+        argument_name="duration",
+    )
+    async def poll(
+        self,
+        ctx: SlashContext,
+        question,
+        options=None,
+        duration: str | None = None,
+    ):
         if options is None:
             options = DEFAULT_POLL_OPTIONS
             emojis = DEFAULT_POLL_EMOJIS
@@ -85,17 +133,31 @@ class PollsExtension(Extension):
                 await send_error(ctx, "Vous ne pouvez pas créer un sondage avec plus de 10 options")
                 return
             emojis = POLL_EMOJIS
-        embed = Embed(
-            title=question,
-            description="\n\n".join([f"{emojis[i]} {option}" for i, option in enumerate(options)]),
-            color=Colors.UTIL,
-        )
+        close_seconds: int | None = None
+        if duration:
+            close_seconds = parse_duration(duration)
+            if close_seconds is None:
+                await send_error(
+                    ctx, "Format de durée invalide. Utilisez par ex. `30m`, `2h`, `1d`."
+                )
+                return
+        description = "\n\n".join([f"{emojis[i]} {option}" for i, option in enumerate(options)])
+        if close_seconds:
+            close_time = datetime.now() + timedelta(seconds=close_seconds)
+            description += (
+                f"\n\n*Fermeture automatique : {format_discord_timestamp(close_time, 'R')}*"
+            )
+        embed = Embed(title=question, description=description, color=Colors.UTIL)
         embed.set_footer(
             text=f"Créé par {ctx.user.username} (ID: {ctx.user.id})",
             icon_url=ctx.user.avatar_url,
         )
         message = await ctx.send(embed=embed)
         await _add_poll_reactions(message, options, use_default=(options == DEFAULT_POLL_OPTIONS))
+        if close_seconds:
+            self._schedule_reaction_close(
+                ctx.guild_id, message, close_seconds, options, emojis
+            )
         logger.debug(
             "Création d'un sondage par %s (ID: %s)\nQuestion : %s\nOptions : %s",
             ctx.user.username,
@@ -103,6 +165,199 @@ class PollsExtension(Extension):
             question,
             options,
         )
+
+    def _schedule_reaction_close(
+        self,
+        guild_id,
+        message,
+        seconds: int,
+        options: list[str],
+        emojis: list[str],
+    ) -> None:
+        async def _close():
+            try:
+                await asyncio.sleep(seconds)
+                fresh = await message.channel.fetch_message(message.id)
+                if not fresh or not fresh.embeds:
+                    return
+                embed = fresh.embeds[0]
+                # Re-render the description without the relative-timestamp note.
+                embed.description = "\n\n".join(
+                    f"{emojis[i]} {option}" for i, option in enumerate(options)
+                )
+                embed.title = f"🔒 {embed.title}"
+                embed.color = Colors.WARNING
+                await fresh.edit(embed=embed)
+                with contextlib.suppress(Exception):
+                    await fresh.clear_all_reactions()
+            except Exception as e:
+                logger.warning("Reaction poll auto-close failed: %s", e)
+            finally:
+                _reaction_close_tasks.pop((str(guild_id), str(message.id)), None)
+
+        task = asyncio.create_task(_close())
+        _reaction_close_tasks[(str(guild_id), str(message.id))] = task
+
+    @slash_command(
+        name="poll-anonyme",
+        description="Créer un sondage à vote anonyme (boutons)",
+        scopes=enabled_servers_int,  # type: ignore
+    )
+    @slash_option(
+        "question",
+        "Question du sondage",
+        opt_type=OptionType.STRING,
+        required=True,
+    )
+    @slash_option(
+        "options",
+        "Options du sondage, séparées par des point-virgules",
+        opt_type=OptionType.STRING,
+        required=True,
+    )
+    @slash_option(
+        "duree",
+        "Fermeture automatique (ex: 30m, 2h, 1d)",
+        opt_type=OptionType.STRING,
+        required=False,
+        argument_name="duration",
+    )
+    async def poll_anonyme(
+        self,
+        ctx: SlashContext,
+        question: str,
+        options: str,
+        duration: str | None = None,
+    ):
+        await self._create_button_poll(ctx, question, options, duration, mode="anonymous")
+
+    @slash_command(
+        name="poll-classement",
+        description="Créer un sondage à vote alternatif (ranked-choice)",
+        scopes=enabled_servers_int,  # type: ignore
+    )
+    @slash_option(
+        "question",
+        "Question du sondage",
+        opt_type=OptionType.STRING,
+        required=True,
+    )
+    @slash_option(
+        "options",
+        "Options du sondage, séparées par des point-virgules",
+        opt_type=OptionType.STRING,
+        required=True,
+    )
+    @slash_option(
+        "duree",
+        "Fermeture automatique (ex: 30m, 2h, 1d)",
+        opt_type=OptionType.STRING,
+        required=False,
+        argument_name="duration",
+    )
+    async def poll_classement(
+        self,
+        ctx: SlashContext,
+        question: str,
+        options: str,
+        duration: str | None = None,
+    ):
+        await self._create_button_poll(ctx, question, options, duration, mode="ranked")
+
+    async def _create_button_poll(
+        self,
+        ctx: SlashContext,
+        question: str,
+        options_text: str,
+        duration: str | None,
+        mode: str,
+    ) -> None:
+        if not ctx.guild_id:
+            await send_error(ctx, "Cette commande est réservée aux serveurs.")
+            return
+        options = [opt.strip() for opt in options_text.split(";") if opt.strip()]
+        if len(options) < 2 or not validate_poll_options(options):
+            await send_error(ctx, "Indiquez entre 2 et 10 options séparées par `;`.")
+            return
+
+        closes_at: datetime | None = None
+        if duration:
+            seconds = parse_duration(duration)
+            if seconds is None:
+                await send_error(
+                    ctx, "Format de durée invalide. Utilisez par ex. `30m`, `2h`, `1d`."
+                )
+                return
+            closes_at = datetime.now() + timedelta(seconds=seconds)
+
+        mode_label = "anonyme" if mode == "anonymous" else "classement"
+        embed = Embed(
+            title=f"📊 {question}",
+            description=f"*Sondage {mode_label}* — cliquez sur un bouton pour voter."
+            + (
+                f"\nFermeture : {format_discord_timestamp(closes_at, 'R')}"
+                if closes_at
+                else ""
+            ),
+            color=Colors.UTIL,
+        )
+        embed.set_footer(
+            text=f"Créé par {ctx.user.username} (ID: {ctx.user.id})",
+            icon_url=ctx.user.avatar_url,
+        )
+        # Placeholder send so we have a message ID to embed in custom_ids.
+        message = await ctx.send(embed=embed)
+
+        poll = Poll(
+            channel_id=str(message.channel.id),
+            message_id=str(message.id),
+            author_id=str(ctx.user.id),
+            question=question,
+            options=options,
+            mode=mode,  # type: ignore[arg-type]
+            closes_at=closes_at,
+        )
+        poll.id = await self._poll_repo(ctx.guild_id).add(poll)
+
+        name, value = render_results_field(poll)
+        embed.add_field(name=name, value=value, inline=False)
+        await message.edit(embed=embed, components=vote_components(poll))
+
+    @Task.create(IntervalTrigger(seconds=30))
+    async def check_closing_polls(self) -> None:
+        now = datetime.now()
+        for gid in enabled_servers:
+            try:
+                due = await self._poll_repo(gid).list_due(now)
+            except Exception as e:
+                logger.error("Failed to fetch due polls for guild %s: %s", gid, e)
+                continue
+            for poll in due:
+                if poll.id is None:
+                    continue
+                await self._close_button_poll(gid, poll)
+
+    async def _close_button_poll(self, guild_id: str, poll: Poll) -> None:
+        try:
+            channel = await self.bot.fetch_channel(int(poll.channel_id))
+            message = await channel.fetch_message(int(poll.message_id))
+        except Exception as e:
+            logger.warning(
+                "Could not fetch poll %s in channel %s: %s", poll.id, poll.channel_id, e
+            )
+            await self._poll_repo(guild_id).mark_closed(poll.id)
+            return
+
+        poll.closed = True
+        embed = message.embeds[0] if message.embeds else Embed(title=f"📊 {poll.question}")
+        if not embed.title.startswith("🔒"):
+            embed.title = f"🔒 {embed.title}"
+        update_poll_embed(embed, poll)
+        try:
+            await message.edit(embed=embed, components=vote_components(poll))
+        except Exception as e:
+            logger.warning("Could not edit closed poll %s: %s", poll.id, e)
+        await self._poll_repo(guild_id).mark_closed(poll.id)
 
     @listen(MessageReactionAdd)
     async def on_message_reaction_add(self, event: MessageReactionAdd):

--- a/extensions/polls/buttons.py
+++ b/extensions/polls/buttons.py
@@ -135,9 +135,7 @@ class PollButtonsMixin:
 
         if poll.mode == "ranked":
             if option_idx in existing:
-                feedback = (
-                    f"Cette option est déjà à la position #{existing.index(option_idx) + 1}."
-                )
+                feedback = f"Cette option est déjà à la position #{existing.index(option_idx) + 1}."
                 await ctx.send(feedback, ephemeral=True)
                 return
             new_ranking = [*existing, option_idx]

--- a/extensions/polls/buttons.py
+++ b/extensions/polls/buttons.py
@@ -1,0 +1,190 @@
+"""Button-based voting for anonymous and ranked-choice polls."""
+
+import re
+
+from interactions import ActionRow, Button, ButtonStyle, ComponentContext, Embed, component_callback
+
+from features.polls import (
+    POLL_EMOJIS,
+    Poll,
+    PollRepository,
+    render_bar,
+    tally_first_past_post,
+    tally_ranked_choice,
+)
+from src.discord_ext.embeds import Colors
+
+VOTE_PREFIX = "poll_vote"
+RESET_PREFIX = "poll_reset"
+
+_VOTE_RE = re.compile(rf"^{VOTE_PREFIX}:([0-9a-fA-F]+):(\d+)$")
+_RESET_RE = re.compile(rf"^{RESET_PREFIX}:([0-9a-fA-F]+)$")
+
+
+def vote_components(poll: Poll) -> list[ActionRow]:
+    """Build button rows for a button-based poll. ≤5 buttons per row, ≤5 rows."""
+    rows: list[ActionRow] = []
+    buttons: list[Button] = []
+    for i, option in enumerate(poll.options):
+        label = option if len(option) <= 70 else option[:67] + "…"
+        buttons.append(
+            Button(
+                label=f"{i + 1}. {label}",
+                emoji=POLL_EMOJIS[i] if i < len(POLL_EMOJIS) else None,
+                style=ButtonStyle.PRIMARY,
+                custom_id=f"{VOTE_PREFIX}:{poll.id}:{i}",
+                disabled=poll.closed,
+            )
+        )
+        if len(buttons) == 5:
+            rows.append(ActionRow(*buttons))
+            buttons = []
+    if buttons:
+        rows.append(ActionRow(*buttons))
+
+    if poll.mode == "ranked" and not poll.closed:
+        rows.append(
+            ActionRow(
+                Button(
+                    label="Réinitialiser mon classement",
+                    style=ButtonStyle.SECONDARY,
+                    custom_id=f"{RESET_PREFIX}:{poll.id}",
+                )
+            )
+        )
+    return rows
+
+
+def render_results_field(poll: Poll) -> tuple[str, str]:
+    """Build a (name, value) results field reflecting the poll's current state."""
+    voter_count = len(poll.votes)
+    if poll.mode == "ranked":
+        rounds, winner = tally_ranked_choice(poll.votes, len(poll.options))
+        if not rounds:
+            return ("Résultats", f"Aucun vote pour le moment ({voter_count} votant(s))")
+        last = rounds[-1]
+        total = sum(last) or 1
+        lines = []
+        for i, count in enumerate(last):
+            marker = "🏆 " if (winner is not None and i == winner) else ""
+            lines.append(
+                f"{marker}{POLL_EMOJIS[i] if i < len(POLL_EMOJIS) else '•'} "
+                f"**{poll.options[i]}** — {render_bar(count, total)} {count}"
+            )
+        rounds_note = f"\n*{len(rounds)} tour(s) IRV — {voter_count} votant(s)*"
+        return ("Résultats (vote alternatif)", "\n".join(lines) + rounds_note)
+
+    counts = tally_first_past_post(poll.votes, len(poll.options))
+    total = sum(counts) or 1
+    lines = []
+    for i, count in enumerate(counts):
+        lines.append(
+            f"{POLL_EMOJIS[i] if i < len(POLL_EMOJIS) else '•'} "
+            f"**{poll.options[i]}** — {render_bar(count, total)} {count}"
+        )
+    return ("Résultats", "\n".join(lines) + f"\n*{voter_count} votant(s)*")
+
+
+_RESULTS_FIELD_NAMES = {"Résultats", "Résultats (vote alternatif)"}
+
+
+def update_poll_embed(embed: Embed, poll: Poll) -> Embed:
+    """Refresh the results field on a poll embed in place."""
+    name, value = render_results_field(poll)
+    # Update an existing results field in place when present (preserves field
+    # ordering and avoids relying on bulk-assignment to embed.fields, which
+    # behaves inconsistently across interactions.py versions).
+    for field in embed.fields or []:
+        if field.name in _RESULTS_FIELD_NAMES:
+            field.name = name
+            field.value = value
+            field.inline = False
+            break
+    else:
+        embed.add_field(name=name, value=value, inline=False)
+    if poll.closed:
+        embed.color = Colors.WARNING
+    return embed
+
+
+class PollButtonsMixin:
+    """Component callbacks for button-based and ranked-choice polls."""
+
+    def _poll_repo(self, guild_id: str | int) -> PollRepository: ...  # supplied by extension
+
+    @component_callback(_VOTE_RE)
+    async def on_poll_vote(self, ctx: ComponentContext) -> None:
+        match = _VOTE_RE.match(ctx.custom_id)
+        if not match or not ctx.guild_id:
+            return
+        poll_id, option_idx = match.group(1), int(match.group(2))
+
+        repo = self._poll_repo(ctx.guild_id)
+        poll = await repo.get_by_message(str(ctx.message.id))
+        if poll is None or poll.id != poll_id:
+            await ctx.send("Sondage introuvable.", ephemeral=True)
+            return
+        if poll.closed:
+            await ctx.send("Ce sondage est fermé.", ephemeral=True)
+            return
+        if option_idx >= len(poll.options):
+            return
+
+        user_id = str(ctx.author.id)
+        existing = poll.votes.get(user_id, [])
+
+        if poll.mode == "ranked":
+            if option_idx in existing:
+                feedback = (
+                    f"Cette option est déjà à la position #{existing.index(option_idx) + 1}."
+                )
+                await ctx.send(feedback, ephemeral=True)
+                return
+            new_ranking = [*existing, option_idx]
+            await repo.set_vote(poll.id, user_id, new_ranking)
+            ranking_text = " → ".join(
+                f"#{pos + 1} {poll.options[idx]}" for pos, idx in enumerate(new_ranking)
+            )
+            feedback = f"Classement enregistré : {ranking_text}"
+        else:
+            new_ranking = [option_idx]
+            await repo.set_vote(poll.id, user_id, new_ranking)
+            anonymous_note = " (anonyme)" if poll.mode == "anonymous" else ""
+            feedback = f"Vote pour **{poll.options[option_idx]}** enregistré{anonymous_note}."
+
+        # Refresh the public embed for non-anonymous polls; anonymous polls keep
+        # the same embed view (counts are still public — only voter identities
+        # are hidden, since reactions aren't used).
+        poll.votes[user_id] = new_ranking
+        try:
+            embed = ctx.message.embeds[0]
+            update_poll_embed(embed, poll)
+            await ctx.message.edit(embed=embed)
+        except Exception:
+            pass
+        await ctx.send(feedback, ephemeral=True)
+
+    @component_callback(_RESET_RE)
+    async def on_poll_reset(self, ctx: ComponentContext) -> None:
+        match = _RESET_RE.match(ctx.custom_id)
+        if not match or not ctx.guild_id:
+            return
+        poll_id = match.group(1)
+        repo = self._poll_repo(ctx.guild_id)
+        poll = await repo.get_by_message(str(ctx.message.id))
+        if poll is None or poll.id != poll_id or poll.closed:
+            await ctx.send("Sondage introuvable ou fermé.", ephemeral=True)
+            return
+        user_id = str(ctx.author.id)
+        if user_id not in poll.votes:
+            await ctx.send("Vous n'avez pas encore voté.", ephemeral=True)
+            return
+        await repo.clear_vote(poll.id, user_id)
+        poll.votes.pop(user_id, None)
+        try:
+            embed = ctx.message.embeds[0]
+            update_poll_embed(embed, poll)
+            await ctx.message.edit(embed=embed)
+        except Exception:
+            pass
+        await ctx.send("Classement réinitialisé.", ephemeral=True)

--- a/extensions/reminders/__init__.py
+++ b/extensions/reminders/__init__.py
@@ -48,8 +48,21 @@ MAX_EXTRA_RECIPIENTS = 25
 _SNOOZE_RE = re.compile(rf"^{SNOOZE_PREFIX}:(\d+):([0-9a-fA-F]+)$")
 
 logger = logutil.init_logger(os.path.basename(__file__))
-_, _, enabled_servers = load_config("moduleUtils")
+_, _module_config, enabled_servers = load_config("moduleUtils")
 enabled_servers_int = [int(s) for s in enabled_servers]  # type: ignore[misc]
+
+
+def _snooze_minutes(guild_id: str | int | None) -> int:
+    """Per-guild snooze duration with a sane fallback to the module default."""
+    if guild_id is None:
+        return SNOOZE_MINUTES
+    cfg = _module_config.get(str(guild_id), {})
+    raw = cfg.get("reminderSnoozeMinutes")
+    try:
+        value = int(raw) if raw is not None else SNOOZE_MINUTES
+    except (TypeError, ValueError):
+        value = SNOOZE_MINUTES
+    return max(1, min(value, 1440))
 
 
 def _parse_recipients(raw: str | None) -> list[str] | None:
@@ -327,11 +340,11 @@ class RemindersExtension(Extension):
         return None
 
     @staticmethod
-    def _snooze_components(reminder_id: str, guild_id: str) -> list[ActionRow]:
+    def _snooze_components(reminder_id: str, guild_id: str, snooze_minutes: int) -> list[ActionRow]:
         return [
             ActionRow(
                 Button(
-                    label=f"Snooze {SNOOZE_MINUTES} min",
+                    label=f"Snooze {snooze_minutes} min",
                     style=ButtonStyle.SECONDARY,
                     custom_id=f"{SNOOZE_PREFIX}:{guild_id}:{reminder_id}",
                 )
@@ -340,15 +353,16 @@ class RemindersExtension(Extension):
 
     @component_callback(_SNOOZE_RE)
     async def on_snooze(self, ctx: ComponentContext):
-        """Re-fire the reminder for the clicker in ``SNOOZE_MINUTES`` minutes."""
+        """Re-fire the reminder for the clicker after the per-guild snooze delay."""
         match = _SNOOZE_RE.match(ctx.custom_id)
         if not match:
             await ctx.send("Bouton invalide.", ephemeral=True)
             return
         gid, reminder_id = match.group(1), match.group(2)
+        minutes = _snooze_minutes(gid)
 
         original_message = ctx.message.content if ctx.message and ctx.message.content else "Rappel"
-        new_time = datetime.now() + timedelta(minutes=SNOOZE_MINUTES)
+        new_time = datetime.now() + timedelta(minutes=minutes)
         snoozed = Reminder(
             user_id=str(ctx.author.id),
             message=f"⏰ (snooze) {original_message}",
@@ -362,7 +376,7 @@ class RemindersExtension(Extension):
             return
 
         await ctx.send(
-            f"Rappel reporté de {SNOOZE_MINUTES} minutes "
+            f"Rappel reporté de {minutes} minutes "
             f"({timestamp_converter(new_time).format(TimestampStyles.RelativeTime)}).",
             ephemeral=True,
         )
@@ -401,15 +415,13 @@ class RemindersExtension(Extension):
 
     async def _dispatch_reminder(self, gid: str, reminder: Reminder) -> None:
         """DM each recipient with a snooze button. Errors are logged per-recipient."""
-        components = self._snooze_components(reminder.id or "", gid)
+        components = self._snooze_components(reminder.id or "", gid, _snooze_minutes(gid))
         for recipient_id in reminder.all_recipients():
             try:
                 _, user = await fetch_user_safe(self.bot, recipient_id)
                 if user:
                     await user.send(reminder.message, components=components)
-                    logger.info(
-                        "Reminder sent to %s: %s", user.display_name, reminder.message
-                    )
+                    logger.info("Reminder sent to %s: %s", user.display_name, reminder.message)
             except Exception as e:
                 logger.warning("Failed to send reminder to user %s: %s", recipient_id, e)
 

--- a/extensions/reminders/__init__.py
+++ b/extensions/reminders/__init__.py
@@ -1,16 +1,18 @@
 """Reminders Discord extension — /reminder slash command and due-check task.
 
 Slash commands:
-- ``/reminder set`` — create a reminder (optional recurrence: daily/weekly/monthly/yearly)
+- ``/reminder set`` — create a reminder (optional recurrence + extra recipients)
 - ``/reminder remove`` — interactive button list to delete one of your reminders
 
-The background ``check_reminders`` task polls every minute, DMs the author,
-and either reschedules recurring reminders or deletes one-shot reminders.
-Persistence lives in :class:`features.reminders.ReminderRepository` (MongoDB).
-Enabled per-guild via ``moduleUtils``.
+The background ``check_reminders`` task polls every minute, DMs each recipient,
+attaches a "Snooze 10 min" button, and either reschedules recurring reminders
+or deletes one-shot reminders. Persistence lives in
+:class:`features.reminders.ReminderRepository` (MongoDB). Enabled per-guild via
+``moduleUtils``.
 """
 
 import os
+import re
 from datetime import datetime, timedelta
 
 from dateutil.relativedelta import relativedelta
@@ -19,6 +21,7 @@ from interactions import (
     Button,
     ButtonStyle,
     Client,
+    ComponentContext,
     Extension,
     IntervalTrigger,
     OptionType,
@@ -26,6 +29,7 @@ from interactions import (
     SlashContext,
     Task,
     TimestampStyles,
+    component_callback,
     listen,
     slash_command,
     slash_option,
@@ -37,9 +41,42 @@ from src.core import logging as logutil
 from src.core.config import load_config
 from src.discord_ext.messages import fetch_user_safe, send_error
 
+SNOOZE_PREFIX = "reminder_snooze"
+SNOOZE_MINUTES = 10
+RECIPIENT_SEPARATORS = ",; "
+MAX_EXTRA_RECIPIENTS = 25
+_SNOOZE_RE = re.compile(rf"^{SNOOZE_PREFIX}:(\d+):([0-9a-fA-F]+)$")
+
 logger = logutil.init_logger(os.path.basename(__file__))
 _, _, enabled_servers = load_config("moduleUtils")
 enabled_servers_int = [int(s) for s in enabled_servers]  # type: ignore[misc]
+
+
+def _parse_recipients(raw: str | None) -> list[str] | None:
+    """Parse a free-text recipient list into a list of Discord user IDs.
+
+    Accepts mentions ``<@123>`` / ``<@!123>`` and bare numeric IDs separated
+    by commas, semicolons, or whitespace. Returns ``None`` on malformed input.
+    """
+    if not raw:
+        return []
+    out: list[str] = []
+    seen: set[str] = set()
+    chunk = raw
+    for sep in RECIPIENT_SEPARATORS:
+        chunk = chunk.replace(sep, " ")
+    for token in chunk.split():
+        token = token.strip()
+        if not token:
+            continue
+        if token.startswith("<@") and token.endswith(">"):
+            token = token[2:-1].lstrip("!&")
+        if not token.isdigit():
+            return None
+        if token not in seen:
+            seen.add(token)
+            out.append(token)
+    return out
 
 
 class RemindersExtension(Extension):
@@ -111,6 +148,13 @@ class RemindersExtension(Extension):
         OptionType.STRING,
         required=False,
     )
+    @slash_option(
+        "destinataires",
+        "IDs ou mentions Discord supplémentaires, séparés par des virgules/espaces",
+        OptionType.STRING,
+        required=False,
+        argument_name="recipients",
+    )
     async def reminder_set(
         self,
         ctx: SlashContext,
@@ -119,6 +163,7 @@ class RemindersExtension(Extension):
         task: str,
         frequency: str | None = None,
         date: str | None = None,
+        recipients: str | None = None,
     ):
         current_time = datetime.now()
         remind_time = current_time.replace(
@@ -152,25 +197,45 @@ class RemindersExtension(Extension):
             elif frequency == "yearly":
                 remind_time += relativedelta(years=1)
 
+        recipient_ids = _parse_recipients(recipients)
+        if recipient_ids is None:
+            await send_error(
+                ctx,
+                "Liste de destinataires invalide. Utilisez des IDs Discord ou "
+                "des mentions séparés par des virgules.",
+            )
+            return
+        if len(recipient_ids) > MAX_EXTRA_RECIPIENTS:
+            await send_error(
+                ctx, f"Pas plus de {MAX_EXTRA_RECIPIENTS} destinataires supplémentaires."
+            )
+            return
+
         gid = str(ctx.guild_id)
         reminder = Reminder(
             user_id=str(ctx.author.id),
             message=task,
             remind_time=remind_time,
             frequency=frequency,  # type: ignore[arg-type]
+            recipient_ids=recipient_ids,
         )
         await self._reminder_repo(gid).add(reminder)
 
+        recipients_suffix = (
+            f" (partagé avec {len(recipient_ids)} personne(s))" if recipient_ids else ""
+        )
         await ctx.send(
-            f"Rappel {frequency} créé à {remind_time.strftime('%H:%M')} avec le message: {task}",
+            f"Rappel {frequency or ''} créé à {remind_time.strftime('%H:%M')}"
+            f" avec le message: {task}{recipients_suffix}",
             ephemeral=True,
         )
         logger.info(
-            "Reminder set for %s at %s with message %s (%s)",
+            "Reminder set for %s at %s with message %s (%s, +%d recipients)",
             ctx.author.display_name,
             remind_time.strftime("%H:%M"),
             task,
             frequency,
+            len(recipient_ids),
         )
 
     @reminder_set.subcommand(
@@ -261,6 +326,47 @@ class RemindersExtension(Extension):
             return remind_time + relativedelta(years=1)
         return None
 
+    @staticmethod
+    def _snooze_components(reminder_id: str, guild_id: str) -> list[ActionRow]:
+        return [
+            ActionRow(
+                Button(
+                    label=f"Snooze {SNOOZE_MINUTES} min",
+                    style=ButtonStyle.SECONDARY,
+                    custom_id=f"{SNOOZE_PREFIX}:{guild_id}:{reminder_id}",
+                )
+            )
+        ]
+
+    @component_callback(_SNOOZE_RE)
+    async def on_snooze(self, ctx: ComponentContext):
+        """Re-fire the reminder for the clicker in ``SNOOZE_MINUTES`` minutes."""
+        match = _SNOOZE_RE.match(ctx.custom_id)
+        if not match:
+            await ctx.send("Bouton invalide.", ephemeral=True)
+            return
+        gid, reminder_id = match.group(1), match.group(2)
+
+        original_message = ctx.message.content if ctx.message and ctx.message.content else "Rappel"
+        new_time = datetime.now() + timedelta(minutes=SNOOZE_MINUTES)
+        snoozed = Reminder(
+            user_id=str(ctx.author.id),
+            message=f"⏰ (snooze) {original_message}",
+            remind_time=new_time,
+        )
+        try:
+            await self._reminder_repo(gid).add(snoozed)
+        except Exception as e:
+            logger.error("Failed to snooze reminder %s: %s", reminder_id, e)
+            await ctx.send("Impossible de reporter le rappel.", ephemeral=True)
+            return
+
+        await ctx.send(
+            f"Rappel reporté de {SNOOZE_MINUTES} minutes "
+            f"({timestamp_converter(new_time).format(TimestampStyles.RelativeTime)}).",
+            ephemeral=True,
+        )
+
     @Task.create(IntervalTrigger(minutes=1))
     async def check_reminders(self):
         now = datetime.now()
@@ -275,14 +381,7 @@ class RemindersExtension(Extension):
             for reminder in due:
                 if reminder.id is None:
                     continue
-                try:
-                    _, user = await fetch_user_safe(self.bot, reminder.user_id)
-                    if user:
-                        await user.send(reminder.message)
-                        logger.info("Reminder sent to %s: %s", user.display_name, reminder.message)
-                except Exception as e:
-                    logger.warning("Failed to send reminder to user %s: %s", reminder.user_id, e)
-                    continue
+                await self._dispatch_reminder(gid, reminder)
 
                 next_time = self._next_occurrence(reminder.remind_time, reminder.frequency)
                 try:
@@ -299,6 +398,20 @@ class RemindersExtension(Extension):
                     logger.error(
                         "Failed to update reminder %s in guild %s: %s", reminder.id, gid, e
                     )
+
+    async def _dispatch_reminder(self, gid: str, reminder: Reminder) -> None:
+        """DM each recipient with a snooze button. Errors are logged per-recipient."""
+        components = self._snooze_components(reminder.id or "", gid)
+        for recipient_id in reminder.all_recipients():
+            try:
+                _, user = await fetch_user_safe(self.bot, recipient_id)
+                if user:
+                    await user.send(reminder.message, components=components)
+                    logger.info(
+                        "Reminder sent to %s: %s", user.display_name, reminder.message
+                    )
+            except Exception as e:
+                logger.warning("Failed to send reminder to user %s: %s", recipient_id, e)
 
 
 def setup(bot: Client) -> None:

--- a/extensions/tricount/__init__.py
+++ b/extensions/tricount/__init__.py
@@ -8,9 +8,7 @@ from .recurring import RecurringMixin
 from .reports import ReportsMixin
 
 
-class TricountExtension(
-    GroupsMixin, ExpensesMixin, RecurringMixin, ReportsMixin, Extension
-):
+class TricountExtension(GroupsMixin, ExpensesMixin, RecurringMixin, ReportsMixin, Extension):
     """Discord extension combining group management, expenses, recurring, and reports."""
 
     def __init__(self, bot: Client):

--- a/extensions/tricount/__init__.py
+++ b/extensions/tricount/__init__.py
@@ -4,11 +4,14 @@ from interactions import Client, Extension
 
 from .expenses import ExpensesMixin
 from .groups import GroupsMixin
+from .recurring import RecurringMixin
 from .reports import ReportsMixin
 
 
-class TricountExtension(GroupsMixin, ExpensesMixin, ReportsMixin, Extension):
-    """Discord extension combining group management, expenses, and reporting."""
+class TricountExtension(
+    GroupsMixin, ExpensesMixin, RecurringMixin, ReportsMixin, Extension
+):
+    """Discord extension combining group management, expenses, recurring, and reports."""
 
     def __init__(self, bot: Client):
         self.bot: Client = bot

--- a/extensions/tricount/_common.py
+++ b/extensions/tricount/_common.py
@@ -5,21 +5,7 @@ import os
 from src.core import logging as logutil
 from src.core.config import load_config
 from src.core.db import mongo_manager
-from src.webui.schemas import SchemaBase, enabled_field, register_module
-
-
-@register_module("moduleTricount")
-class TricountConfig(SchemaBase):
-    __label__ = "Tricount"
-    __description__ = "Gestion des dépenses partagées."
-    __icon__ = "💰"
-    __category__ = "Outils"
-
-    enabled: bool = enabled_field()
-
-
-logger = logutil.init_logger(os.path.basename(__file__))
-config, module_config, enabled_servers = load_config("moduleTricount")
+from src.webui.schemas import SchemaBase, enabled_field, register_module, ui
 
 # Default expense categories surfaced in /depense autocomplete. Free-form input
 # is also accepted so guilds can use their own taxonomy.
@@ -35,6 +21,47 @@ DEFAULT_CATEGORIES = [
 ]
 
 DEFAULT_CATEGORY = "Autre"
+DEFAULT_CURRENCY = "€"
+
+
+@register_module("moduleTricount")
+class TricountConfig(SchemaBase):
+    __label__ = "Tricount"
+    __description__ = "Gestion des dépenses partagées."
+    __icon__ = "💰"
+    __category__ = "Outils"
+
+    enabled: bool = enabled_field()
+    tricountCurrency: str = ui(
+        "Devise",
+        "string",
+        default=DEFAULT_CURRENCY,
+        description="Symbole de devise utilisé dans les embeds et les graphiques.",
+    )
+    tricountCategories: list[str] = ui(
+        "Catégories disponibles",
+        "list",
+        description=(
+            "Catégories proposées dans l'autocomplete de /depense. Vide = liste par défaut."
+        ),
+        default=DEFAULT_CATEGORIES,
+    )
+
+
+logger = logutil.init_logger(os.path.basename(__file__))
+config, module_config, enabled_servers = load_config("moduleTricount")
+
+
+def guild_categories(guild_id: str | int) -> list[str]:
+    """Per-guild category list, falling back to defaults when the override is empty."""
+    cfg = module_config.get(str(guild_id), {})
+    custom = cfg.get("tricountCategories") or []
+    return list(custom) if custom else list(DEFAULT_CATEGORIES)
+
+
+def guild_currency(guild_id: str | int) -> str:
+    cfg = module_config.get(str(guild_id), {})
+    return cfg.get("tricountCurrency") or DEFAULT_CURRENCY
 
 
 def groups_col(guild_id):

--- a/extensions/tricount/_common.py
+++ b/extensions/tricount/_common.py
@@ -21,6 +21,21 @@ class TricountConfig(SchemaBase):
 logger = logutil.init_logger(os.path.basename(__file__))
 config, module_config, enabled_servers = load_config("moduleTricount")
 
+# Default expense categories surfaced in /depense autocomplete. Free-form input
+# is also accepted so guilds can use their own taxonomy.
+DEFAULT_CATEGORIES = [
+    "Alimentation",
+    "Logement",
+    "Transport",
+    "Loisirs",
+    "Restaurant",
+    "Cadeaux",
+    "Voyages",
+    "Autre",
+]
+
+DEFAULT_CATEGORY = "Autre"
+
 
 def groups_col(guild_id):
     return mongo_manager.get_guild_collection(str(guild_id), "tricount_groups")
@@ -28,3 +43,7 @@ def groups_col(guild_id):
 
 def expenses_col(guild_id):
     return mongo_manager.get_guild_collection(str(guild_id), "tricount_expenses")
+
+
+def recurring_col(guild_id):
+    return mongo_manager.get_guild_collection(str(guild_id), "tricount_recurring")

--- a/extensions/tricount/expenses.py
+++ b/extensions/tricount/expenses.py
@@ -19,7 +19,13 @@ from src.discord_ext.autocomplete import guild_group_autocomplete
 from src.discord_ext.embeds import Colors
 from src.discord_ext.messages import fetch_user_safe, require_guild
 
-from ._common import DEFAULT_CATEGORIES, DEFAULT_CATEGORY, expenses_col, groups_col
+from ._common import (
+    DEFAULT_CATEGORY,
+    expenses_col,
+    groups_col,
+    guild_categories,
+    guild_currency,
+)
 
 logger = logutil.init_logger(os.path.basename(__file__))
 
@@ -112,17 +118,20 @@ class ExpensesMixin:
         }
         await expenses_col(ctx.guild.id).insert_one(expense_data)
 
+        currency = guild_currency(ctx.guild.id)
         embed = Embed(
             title="✅ Dépense ajoutée",
             description=f"Dépense ajoutée au groupe **{groupe}**",
             color=Colors.SUCCESS,
         )
-        embed.add_field(name="Montant", value=f"{montant:.2f}€", inline=True)
+        embed.add_field(name="Montant", value=f"{montant:.2f}{currency}", inline=True)
         embed.add_field(name="Payeur", value=payeur.mention, inline=True)
         embed.add_field(name="Catégorie", value=category, inline=True)
         embed.add_field(name="Description", value=description, inline=False)
         embed.add_field(
-            name="Part par personne", value=f"{montant / len(group['members']):.2f}€", inline=True
+            name="Part par personne",
+            value=f"{montant / len(group['members']):.2f}{currency}",
+            inline=True,
         )
         logger.info(
             "Dépense de %.2f€ ajoutée par %s au groupe '%s' (payeur: %s, catégorie: %s)",
@@ -139,7 +148,7 @@ class ExpensesMixin:
         query = (ctx.input_text or "").lower()
         seen: set[str] = set()
         choices: list[dict[str, str]] = []
-        for cat in DEFAULT_CATEGORIES:
+        for cat in guild_categories(ctx.guild.id) if ctx.guild else []:
             if query in cat.lower() and cat not in seen:
                 seen.add(cat)
                 choices.append({"name": cat, "value": cat})

--- a/extensions/tricount/expenses.py
+++ b/extensions/tricount/expenses.py
@@ -19,7 +19,7 @@ from src.discord_ext.autocomplete import guild_group_autocomplete
 from src.discord_ext.embeds import Colors
 from src.discord_ext.messages import fetch_user_safe, require_guild
 
-from ._common import expenses_col, groups_col
+from ._common import DEFAULT_CATEGORIES, DEFAULT_CATEGORY, expenses_col, groups_col
 
 logger = logutil.init_logger(os.path.basename(__file__))
 
@@ -57,6 +57,13 @@ class ExpensesMixin:
         opt_type=OptionType.USER,
         required=False,
     )
+    @slash_option(
+        name="categorie",
+        description="Catégorie (alimentation, transport, loisirs, …)",
+        opt_type=OptionType.STRING,
+        required=False,
+        autocomplete=True,
+    )
     async def depense(
         self,
         ctx: SlashContext,
@@ -64,6 +71,7 @@ class ExpensesMixin:
         montant: float,
         description: str,
         payeur: User | Member | None = None,
+        categorie: str | None = None,
     ):
         if not await require_guild(ctx):
             return
@@ -90,11 +98,13 @@ class ExpensesMixin:
 
         from datetime import datetime
 
+        category = (categorie or DEFAULT_CATEGORY).strip() or DEFAULT_CATEGORY
         expense_data = {
             "group_id": group["_id"],
             "group_name": groupe,
             "amount": round(montant, 2),
             "description": description,
+            "category": category,
             "payer": payeur.id,
             "added_by": ctx.author.id,
             "participants": group["members"],
@@ -109,18 +119,45 @@ class ExpensesMixin:
         )
         embed.add_field(name="Montant", value=f"{montant:.2f}€", inline=True)
         embed.add_field(name="Payeur", value=payeur.mention, inline=True)
+        embed.add_field(name="Catégorie", value=category, inline=True)
         embed.add_field(name="Description", value=description, inline=False)
         embed.add_field(
             name="Part par personne", value=f"{montant / len(group['members']):.2f}€", inline=True
         )
         logger.info(
-            "Dépense de %.2f€ ajoutée par %s au groupe '%s' (payeur: %s)",
+            "Dépense de %.2f€ ajoutée par %s au groupe '%s' (payeur: %s, catégorie: %s)",
             montant,
             ctx.author.display_name,
             groupe,
             payeur.display_name,
+            category,
         )
         await ctx.send(embed=embed)
+
+    @depense.autocomplete("categorie")
+    async def depense_categorie_autocomplete(self, ctx: AutocompleteContext):
+        query = (ctx.input_text or "").lower()
+        seen: set[str] = set()
+        choices: list[dict[str, str]] = []
+        for cat in DEFAULT_CATEGORIES:
+            if query in cat.lower() and cat not in seen:
+                seen.add(cat)
+                choices.append({"name": cat, "value": cat})
+        # Surface previously used custom categories from this guild.
+        if ctx.guild:
+            try:
+                used = await expenses_col(ctx.guild.id).distinct("category")
+                for cat in used:
+                    if not cat or cat in seen:
+                        continue
+                    if query in cat.lower():
+                        seen.add(cat)
+                        choices.append({"name": cat, "value": cat})
+                    if len(choices) >= 25:
+                        break
+            except Exception:
+                pass
+        await ctx.send(choices=choices[:25])
 
     @depense.autocomplete("groupe")
     async def depense_groupe_autocomplete(self, ctx: AutocompleteContext):

--- a/extensions/tricount/recurring.py
+++ b/extensions/tricount/recurring.py
@@ -1,0 +1,299 @@
+"""Recurring expenses: scheduled templates that re-create an expense on cadence."""
+
+import os
+from datetime import datetime, timedelta
+
+from bson import ObjectId
+from dateutil.relativedelta import relativedelta
+from interactions import (
+    AutocompleteContext,
+    Embed,
+    IntervalTrigger,
+    OptionType,
+    SlashCommandChoice,
+    SlashContext,
+    Task,
+    listen,
+    slash_command,
+    slash_option,
+)
+
+from src.core import logging as logutil
+from src.discord_ext.autocomplete import guild_group_autocomplete
+from src.discord_ext.embeds import Colors
+from src.discord_ext.messages import require_guild
+
+from ._common import (
+    DEFAULT_CATEGORIES,
+    DEFAULT_CATEGORY,
+    enabled_servers,
+    expenses_col,
+    groups_col,
+    recurring_col,
+)
+
+logger = logutil.init_logger(os.path.basename(__file__))
+
+
+def _next_occurrence(remind_time: datetime, frequency: str) -> datetime:
+    if frequency == "daily":
+        return remind_time + timedelta(days=1)
+    if frequency == "weekly":
+        return remind_time + timedelta(weeks=1)
+    if frequency == "monthly":
+        return remind_time + relativedelta(months=1)
+    if frequency == "yearly":
+        return remind_time + relativedelta(years=1)
+    raise ValueError(f"Unknown frequency: {frequency}")
+
+
+class RecurringMixin:
+    """Manage recurring expense templates."""
+
+    @listen()
+    async def on_startup(self):
+        # Indexes are best-effort; failure here shouldn't break extension load.
+        for guild_id in enabled_servers:
+            try:
+                await recurring_col(guild_id).create_index("next_run", name="next_run_idx")
+                await recurring_col(guild_id).create_index("active", name="active_idx")
+            except Exception as e:
+                logger.debug("Could not init recurring indexes for %s: %s", guild_id, e)
+        self.recurring_tick.start()
+
+    @slash_command(
+        name="depense-recurrente",
+        description="Programmer une dépense récurrente",
+        sub_cmd_name="ajouter",
+        sub_cmd_description="Créer une dépense récurrente",
+    )
+    @slash_option(
+        name="groupe",
+        description="Nom du groupe",
+        opt_type=OptionType.STRING,
+        required=True,
+        autocomplete=True,
+    )
+    @slash_option(
+        name="montant",
+        description="Montant (€)",
+        opt_type=OptionType.NUMBER,
+        required=True,
+    )
+    @slash_option(
+        name="description",
+        description="Description de la dépense",
+        opt_type=OptionType.STRING,
+        required=True,
+        max_length=100,
+    )
+    @slash_option(
+        name="frequence",
+        description="Fréquence",
+        opt_type=OptionType.STRING,
+        required=True,
+        choices=[
+            SlashCommandChoice(name="Quotidien", value="daily"),
+            SlashCommandChoice(name="Hebdomadaire", value="weekly"),
+            SlashCommandChoice(name="Mensuel", value="monthly"),
+            SlashCommandChoice(name="Annuel", value="yearly"),
+        ],
+    )
+    @slash_option(
+        name="categorie",
+        description="Catégorie (par défaut: Autre)",
+        opt_type=OptionType.STRING,
+        required=False,
+        autocomplete=True,
+    )
+    async def depense_recurrente_ajouter(
+        self,
+        ctx: SlashContext,
+        groupe: str,
+        montant: float,
+        description: str,
+        frequence: str,
+        categorie: str | None = None,
+    ):
+        if not await require_guild(ctx):
+            return
+        if montant <= 0:
+            await ctx.send("❌ Le montant doit être positif.", ephemeral=True)
+            return
+
+        group = await groups_col(ctx.guild.id).find_one({"name": groupe, "is_active": True})
+        if not group or ctx.author.id not in group["members"]:
+            await ctx.send("❌ Groupe introuvable ou non membre.", ephemeral=True)
+            return
+
+        category = (categorie or DEFAULT_CATEGORY).strip() or DEFAULT_CATEGORY
+        next_run = _next_occurrence(datetime.now(), frequence)
+        doc = {
+            "group_id": group["_id"],
+            "group_name": groupe,
+            "amount": round(montant, 2),
+            "description": description,
+            "category": category,
+            "payer": ctx.author.id,
+            "added_by": ctx.author.id,
+            "frequency": frequence,
+            "next_run": next_run,
+            "active": True,
+            "created_at": datetime.now(),
+        }
+        result = await recurring_col(ctx.guild.id).insert_one(doc)
+        embed = Embed(
+            title="✅ Dépense récurrente créée",
+            description=(
+                f"**{description}** — {montant:.2f}€ ({frequence})\n"
+                f"Prochaine occurrence : {next_run:%d/%m/%Y %H:%M}"
+            ),
+            color=Colors.SUCCESS,
+        )
+        embed.set_footer(text=f"ID : {result.inserted_id}")
+        await ctx.send(embed=embed)
+
+    @depense_recurrente_ajouter.autocomplete("groupe")
+    async def _ajouter_groupe_ac(self, ctx: AutocompleteContext):
+        await guild_group_autocomplete(ctx, groups_col)
+
+    @depense_recurrente_ajouter.autocomplete("categorie")
+    async def _ajouter_categorie_ac(self, ctx: AutocompleteContext):
+        query = (ctx.input_text or "").lower()
+        choices = [
+            {"name": cat, "value": cat}
+            for cat in DEFAULT_CATEGORIES
+            if query in cat.lower()
+        ]
+        await ctx.send(choices=choices[:25])
+
+    @depense_recurrente_ajouter.subcommand(
+        sub_cmd_name="lister",
+        sub_cmd_description="Voir vos dépenses récurrentes actives",
+    )
+    @slash_option(
+        name="groupe",
+        description="Filtrer par groupe",
+        opt_type=OptionType.STRING,
+        required=False,
+        autocomplete=True,
+    )
+    async def depense_recurrente_lister(self, ctx: SlashContext, groupe: str | None = None):
+        if not await require_guild(ctx):
+            return
+        query: dict = {"active": True, "added_by": ctx.author.id}
+        if groupe:
+            query["group_name"] = groupe
+        docs = (
+            await recurring_col(ctx.guild.id)
+            .find(query)
+            .sort("next_run", 1)
+            .to_list(length=None)
+        )
+        if not docs:
+            await ctx.send("Aucune dépense récurrente active.", ephemeral=True)
+            return
+        embed = Embed(
+            title="🔁 Dépenses récurrentes",
+            description=f"{len(docs)} dépense(s) active(s)",
+            color=Colors.INFO,
+        )
+        for doc in docs[:10]:
+            embed.add_field(
+                name=f"{doc['description']} — {doc['amount']:.2f}€",
+                value=(
+                    f"Groupe : **{doc['group_name']}** · {doc['frequency']}\n"
+                    f"Catégorie : {doc.get('category', DEFAULT_CATEGORY)}\n"
+                    f"Prochaine : {doc['next_run']:%d/%m/%Y %H:%M}\n"
+                    f"ID : `{doc['_id']}`"
+                ),
+                inline=False,
+            )
+        await ctx.send(embed=embed)
+
+    @depense_recurrente_lister.autocomplete("groupe")
+    async def _lister_groupe_ac(self, ctx: AutocompleteContext):
+        await guild_group_autocomplete(ctx, groups_col)
+
+    @depense_recurrente_ajouter.subcommand(
+        sub_cmd_name="arreter",
+        sub_cmd_description="Désactiver une dépense récurrente",
+    )
+    @slash_option(
+        name="recurrence_id",
+        description="ID de la récurrence à arrêter",
+        opt_type=OptionType.STRING,
+        required=True,
+    )
+    async def depense_recurrente_arreter(self, ctx: SlashContext, recurrence_id: str):
+        if not await require_guild(ctx):
+            return
+        try:
+            obj_id = ObjectId(recurrence_id)
+        except Exception:
+            await ctx.send("❌ ID invalide.", ephemeral=True)
+            return
+        result = await recurring_col(ctx.guild.id).update_one(
+            {"_id": obj_id, "added_by": ctx.author.id, "active": True},
+            {"$set": {"active": False}},
+        )
+        if result.modified_count == 0:
+            await ctx.send(
+                "❌ Récurrence introuvable ou déjà arrêtée.", ephemeral=True
+            )
+            return
+        await ctx.send("✅ Récurrence arrêtée.", ephemeral=True)
+
+    @Task.create(IntervalTrigger(minutes=5))
+    async def recurring_tick(self):
+        now = datetime.now()
+        for guild_id in enabled_servers:
+            try:
+                due = (
+                    await recurring_col(guild_id)
+                    .find({"active": True, "next_run": {"$lte": now}})
+                    .to_list(length=None)
+                )
+            except Exception as e:
+                logger.error(
+                    "Could not list due recurring expenses for %s: %s", guild_id, e
+                )
+                continue
+            for doc in due:
+                await self._materialise_recurring(guild_id, doc)
+
+    async def _materialise_recurring(self, guild_id: str, doc: dict) -> None:
+        """Create the next concrete expense and reschedule the recurrence."""
+        try:
+            group = await groups_col(guild_id).find_one(
+                {"_id": doc["group_id"], "is_active": True}
+            )
+            if not group:
+                # Group was deleted — deactivate the recurrence.
+                await recurring_col(guild_id).update_one(
+                    {"_id": doc["_id"]}, {"$set": {"active": False}}
+                )
+                return
+            expense = {
+                "group_id": group["_id"],
+                "group_name": group["name"],
+                "amount": doc["amount"],
+                "description": f"🔁 {doc['description']}",
+                "category": doc.get("category", DEFAULT_CATEGORY),
+                "payer": doc["payer"],
+                "added_by": doc["added_by"],
+                "participants": group["members"],
+                "date": datetime.now(),
+                "recurring_id": doc["_id"],
+            }
+            await expenses_col(guild_id).insert_one(expense)
+            next_run = _next_occurrence(doc["next_run"], doc["frequency"])
+            while next_run <= datetime.now():
+                next_run = _next_occurrence(next_run, doc["frequency"])
+            await recurring_col(guild_id).update_one(
+                {"_id": doc["_id"]}, {"$set": {"next_run": next_run}}
+            )
+        except Exception as e:
+            logger.error(
+                "Failed to materialise recurring expense %s: %s", doc.get("_id"), e
+            )

--- a/extensions/tricount/recurring.py
+++ b/extensions/tricount/recurring.py
@@ -161,9 +161,7 @@ class RecurringMixin:
     async def _ajouter_categorie_ac(self, ctx: AutocompleteContext):
         query = (ctx.input_text or "").lower()
         choices = [
-            {"name": cat, "value": cat}
-            for cat in DEFAULT_CATEGORIES
-            if query in cat.lower()
+            {"name": cat, "value": cat} for cat in DEFAULT_CATEGORIES if query in cat.lower()
         ]
         await ctx.send(choices=choices[:25])
 
@@ -185,10 +183,7 @@ class RecurringMixin:
         if groupe:
             query["group_name"] = groupe
         docs = (
-            await recurring_col(ctx.guild.id)
-            .find(query)
-            .sort("next_run", 1)
-            .to_list(length=None)
+            await recurring_col(ctx.guild.id).find(query).sort("next_run", 1).to_list(length=None)
         )
         if not docs:
             await ctx.send("Aucune dépense récurrente active.", ephemeral=True)
@@ -238,9 +233,7 @@ class RecurringMixin:
             {"$set": {"active": False}},
         )
         if result.modified_count == 0:
-            await ctx.send(
-                "❌ Récurrence introuvable ou déjà arrêtée.", ephemeral=True
-            )
+            await ctx.send("❌ Récurrence introuvable ou déjà arrêtée.", ephemeral=True)
             return
         await ctx.send("✅ Récurrence arrêtée.", ephemeral=True)
 
@@ -255,9 +248,7 @@ class RecurringMixin:
                     .to_list(length=None)
                 )
             except Exception as e:
-                logger.error(
-                    "Could not list due recurring expenses for %s: %s", guild_id, e
-                )
+                logger.error("Could not list due recurring expenses for %s: %s", guild_id, e)
                 continue
             for doc in due:
                 await self._materialise_recurring(guild_id, doc)
@@ -265,9 +256,7 @@ class RecurringMixin:
     async def _materialise_recurring(self, guild_id: str, doc: dict) -> None:
         """Create the next concrete expense and reschedule the recurrence."""
         try:
-            group = await groups_col(guild_id).find_one(
-                {"_id": doc["group_id"], "is_active": True}
-            )
+            group = await groups_col(guild_id).find_one({"_id": doc["group_id"], "is_active": True})
             if not group:
                 # Group was deleted — deactivate the recurrence.
                 await recurring_col(guild_id).update_one(
@@ -294,6 +283,4 @@ class RecurringMixin:
                 {"_id": doc["_id"]}, {"$set": {"next_run": next_run}}
             )
         except Exception as e:
-            logger.error(
-                "Failed to materialise recurring expense %s: %s", doc.get("_id"), e
-            )
+            logger.error("Failed to materialise recurring expense %s: %s", doc.get("_id"), e)

--- a/extensions/tricount/reports.py
+++ b/extensions/tricount/reports.py
@@ -1,22 +1,25 @@
 """Expense reports: list expenses, balance, and group overview."""
 
 import os
+from collections import defaultdict
 
 from interactions import (
     AutocompleteContext,
     Embed,
+    File,
     OptionType,
     SlashContext,
     slash_command,
     slash_option,
 )
 
+from features.tricount import render_category_chart
 from src.core import logging as logutil
 from src.discord_ext.autocomplete import guild_group_autocomplete
 from src.discord_ext.embeds import Colors
 from src.discord_ext.messages import fetch_user_safe, require_guild
 
-from ._common import expenses_col, groups_col
+from ._common import DEFAULT_CATEGORY, expenses_col, groups_col
 
 logger = logutil.init_logger(os.path.basename(__file__))
 
@@ -177,6 +180,63 @@ class ReportsMixin:
 
     @bilan.autocomplete("groupe")
     async def bilan_groupe_autocomplete(self, ctx: AutocompleteContext):
+        await guild_group_autocomplete(ctx, groups_col)
+
+    @slash_command(
+        name="tricount-graphique",
+        description="Exporter un graphique des dépenses par catégorie",
+    )
+    @slash_option(
+        name="groupe",
+        description="Nom du groupe",
+        opt_type=OptionType.STRING,
+        required=True,
+        autocomplete=True,
+    )
+    async def tricount_graphique(self, ctx: SlashContext, groupe: str):
+        if not await require_guild(ctx):
+            return
+        group = await groups_col(ctx.guild.id).find_one({"name": groupe, "is_active": True})
+        if not group:
+            await ctx.send(
+                f"❌ Aucun groupe actif trouvé avec le nom '{groupe}'.", ephemeral=True
+            )
+            return
+        if ctx.author.id not in group["members"]:
+            await ctx.send(
+                "❌ Vous devez être membre du groupe pour voir le graphique.",
+                ephemeral=True,
+            )
+            return
+
+        await ctx.defer()
+        expenses = (
+            await expenses_col(ctx.guild.id)
+            .find({"group_id": group["_id"]})
+            .to_list(length=None)
+        )
+        if not expenses:
+            await ctx.send("Aucune dépense enregistrée dans ce groupe.")
+            return
+
+        totals: dict[str, float] = defaultdict(float)
+        for expense in expenses:
+            cat = expense.get("category") or DEFAULT_CATEGORY
+            totals[cat] += float(expense.get("amount", 0))
+
+        try:
+            buffer = render_category_chart(
+                title=f"Dépenses du groupe {groupe}",
+                category_totals=dict(totals),
+            )
+        except Exception as e:
+            logger.error("Could not render tricount chart: %s", e)
+            await ctx.send("❌ Erreur lors de la génération du graphique.")
+            return
+        await ctx.send(file=File(file=buffer, file_name="tricount.png"))
+
+    @tricount_graphique.autocomplete("groupe")
+    async def graphique_groupe_autocomplete(self, ctx: AutocompleteContext):
         await guild_group_autocomplete(ctx, groups_col)
 
     @slash_command(

--- a/extensions/tricount/reports.py
+++ b/extensions/tricount/reports.py
@@ -19,7 +19,7 @@ from src.discord_ext.autocomplete import guild_group_autocomplete
 from src.discord_ext.embeds import Colors
 from src.discord_ext.messages import fetch_user_safe, require_guild
 
-from ._common import DEFAULT_CATEGORY, expenses_col, groups_col
+from ._common import DEFAULT_CATEGORY, expenses_col, groups_col, guild_currency
 
 logger = logutil.init_logger(os.path.basename(__file__))
 
@@ -198,9 +198,7 @@ class ReportsMixin:
             return
         group = await groups_col(ctx.guild.id).find_one({"name": groupe, "is_active": True})
         if not group:
-            await ctx.send(
-                f"❌ Aucun groupe actif trouvé avec le nom '{groupe}'.", ephemeral=True
-            )
+            await ctx.send(f"❌ Aucun groupe actif trouvé avec le nom '{groupe}'.", ephemeral=True)
             return
         if ctx.author.id not in group["members"]:
             await ctx.send(
@@ -211,9 +209,7 @@ class ReportsMixin:
 
         await ctx.defer()
         expenses = (
-            await expenses_col(ctx.guild.id)
-            .find({"group_id": group["_id"]})
-            .to_list(length=None)
+            await expenses_col(ctx.guild.id).find({"group_id": group["_id"]}).to_list(length=None)
         )
         if not expenses:
             await ctx.send("Aucune dépense enregistrée dans ce groupe.")
@@ -228,6 +224,7 @@ class ReportsMixin:
             buffer = render_category_chart(
                 title=f"Dépenses du groupe {groupe}",
                 category_totals=dict(totals),
+                currency=guild_currency(ctx.guild.id),
             )
         except Exception as e:
             logger.error("Could not render tricount chart: %s", e)

--- a/extensions/twitch/__init__.py
+++ b/extensions/twitch/__init__.py
@@ -9,6 +9,7 @@ change detection live in their own submodules (mixin classes combined below).
 import asyncio
 import json
 import os
+from collections import defaultdict
 
 import pytz
 from interactions import (
@@ -112,6 +113,45 @@ class TwitchExtension(
     def get_streamer_key(self, guild_id: int, streamer_id: str) -> str:
         return f"{guild_id}_{streamer_id}"
 
+    # ─── Scheduled-event matching ─────────────────────────────────────
+
+    @staticmethod
+    def _event_location(event) -> str:
+        """Best-effort extraction of the external_location URL from a scheduled event."""
+        meta = getattr(event, "entity_metadata", None)
+        if meta is not None:
+            location = getattr(meta, "location", None)
+            if location:
+                return str(location)
+        # Fallback for older interactions.py versions that surface it directly.
+        return str(getattr(event, "location", "") or "")
+
+    def _match_scheduled_event(self, streamer: StreamerInfo, bot_events: list):
+        """Pick the scheduled event for ``streamer`` from the guild's bot-owned events.
+
+        Each streamer's event has ``external_location =
+        https://twitch.tv/{user_login}``; the configured ``streamer_id`` key is
+        the same login, so we match on that URL.
+
+        Mutates ``bot_events`` to remove the claimed event so the next streamer
+        in the same guild can't be assigned the same event.
+        """
+        expected = f"https://twitch.tv/{streamer.streamer_id}".lower()
+        for i, event in enumerate(bot_events):
+            if self._event_location(event).lower() == expected:
+                return bot_events.pop(i)
+
+        # Legacy fallback: events created before URL disambiguation existed
+        # had no reliable per-streamer marker. Claim one only if this guild
+        # tracks a single streamer; otherwise leave the event alone — the next
+        # update tick will recreate it for whichever streamer needs it.
+        guild_streamer_count = sum(
+            1 for s in self.streamers.values() if s.guild_id == streamer.guild_id
+        )
+        if guild_streamer_count == 1 and bot_events:
+            return bot_events.pop(0)
+        return None
+
     # ─── Session-state persistence ────────────────────────────────────
 
     @staticmethod
@@ -176,6 +216,32 @@ class TwitchExtension(
 
         await self._load_streamer_states()
 
+        # Pre-fetch each guild's bot-owned scheduled events once so we can
+        # disambiguate events by their external_location URL when multiple
+        # streamers share a guild.
+        streamers_by_guild: dict[int, list[StreamerInfo]] = defaultdict(list)
+        for streamer in self.streamers.values():
+            streamers_by_guild[streamer.guild_id].append(streamer)
+
+        bot_events_by_guild: dict[int, list] = {}
+        for guild_id in streamers_by_guild:
+            try:
+                guild = await self.bot.fetch_guild(guild_id)
+                events = await guild.list_scheduled_events()
+            except Exception as e:
+                logger.error("Error fetching scheduled events for guild %s: %s", guild_id, e)
+                bot_events_by_guild[guild_id] = []
+                continue
+            owned = []
+            for event in events:
+                try:
+                    creator = await event.creator
+                except Exception:
+                    continue
+                if creator and creator.id == self.bot.user.id:
+                    owned.append(event)
+            bot_events_by_guild[guild_id] = owned
+
         for streamer_key, streamer in self.streamers.items():
             try:
                 if streamer.planning_channel_id:
@@ -220,14 +286,14 @@ class TwitchExtension(
                         streamer.notification_channel_id
                     )
 
-                # Attach any existing bot-owned scheduled event to this streamer.
-                # TODO: disambiguate when multiple streamers are tracked in the same guild.
-                guild = await self.bot.fetch_guild(streamer.guild_id)
-                for event in await guild.list_scheduled_events():
-                    creator = await event.creator
-                    if creator.id == self.bot.user.id:
-                        streamer.scheduled_event = event
-                        break
+                # Attach the bot-owned scheduled event whose external_location
+                # URL matches this streamer's Twitch login (case-insensitive).
+                # Falls back to claiming an unclaimed bot event only when this
+                # is the sole streamer in the guild — preserves legacy behavior
+                # for events created before URL disambiguation existed.
+                streamer.scheduled_event = self._match_scheduled_event(
+                    streamer, bot_events_by_guild.get(streamer.guild_id, [])
+                )
             except Exception as e:
                 logger.error(f"Error initializing channels for streamer {streamer_key}: {e}")
 

--- a/extensions/welcome.py
+++ b/extensions/welcome.py
@@ -2,9 +2,11 @@
 
 import os
 
-from interactions import Client, Extension, listen
+import httpx
+from interactions import Client, Extension, File, listen
 from interactions.api.events import MemberAdd, MemberRemove
 
+from features.welcome import render_welcome_card
 from src.core import logging as logutil
 from src.core.config import load_config
 from src.core.text import pick_weighted_message
@@ -25,6 +27,12 @@ class WelcomeConfig(SchemaBase):
         "channel",
         required=True,
         description="Salon où les messages de bienvenue sont envoyés.",
+    )
+    welcomeImageEnabled: bool = ui(
+        "Carte d'accueil illustrée",
+        "boolean",
+        default=True,
+        description="Joindre une image générée avec l'avatar et le pseudo du membre.",
     )
     welcomeMessageList: list[str] = ui(
         "Messages de bienvenue",
@@ -49,6 +57,34 @@ logger = logutil.init_logger(os.path.basename(__file__))
 config, module_config, enabled_servers = load_config("moduleWelcome")
 
 
+async def _fetch_avatar_bytes(member) -> bytes | None:
+    """Best-effort download of the member's avatar PNG."""
+    avatar_url = getattr(member, "display_avatar", None) or getattr(member, "avatar_url", None)
+    if avatar_url is None:
+        return None
+    url = str(avatar_url)
+    if "?" in url:
+        url = url.split("?", 1)[0]
+    if "." in url.rsplit("/", 1)[-1]:
+        # Force PNG so animated avatars decode to a still frame.
+        url = url.rsplit(".", 1)[0] + ".png"
+    url = f"{url}?size=256"
+    try:
+        async with httpx.AsyncClient(timeout=8.0) as client:
+            response = await client.get(url)
+            response.raise_for_status()
+            return response.content
+    except Exception as e:
+        logger.debug("Could not fetch avatar for %s: %s", getattr(member, "id", "?"), e)
+        return None
+
+
+def _server_name_subtitle(guild_name: str, member_count: int | None) -> str:
+    if member_count:
+        return f"{guild_name} · {member_count} membres"
+    return guild_name
+
+
 class WelcomeExtension(Extension):
     def __init__(self, bot: Client):
         self.bot = bot
@@ -56,14 +92,7 @@ class WelcomeExtension(Extension):
 
     @listen()
     async def on_member_add(self, event: MemberAdd):
-        """
-        A listener that sends a message when a member joins a guild.
-
-        Parameters:
-        -----------
-        event : interactions.Member
-            The member that joined the guild.
-        """
+        """A listener that sends a message when a member joins a guild."""
         logger.info("Member %s joined the server %s", event.member.username, event.guild.name)
         if not is_guild_enabled(event.guild.id, enabled_servers):
             logger.info("Server not enabled")
@@ -77,23 +106,20 @@ class WelcomeExtension(Extension):
             "Bienvenue {mention} !",
             mention=event.member.mention,
         )
-        # Get the welcome channel
         channel = event.guild.get_channel(
             serv_config.get("welcomeChannelId") or event.guild.system_channel.id
         )
-        # Send the welcome message
-        await channel.send(filled_message)
+        files = await self._build_card_files(
+            event.member,
+            event.guild,
+            title="Bienvenue",
+            enabled=serv_config.get("welcomeImageEnabled", True),
+        )
+        await channel.send(filled_message, files=files)
 
     @listen()
     async def on_member_remove(self, event: MemberRemove):
-        """
-        A listener that sends a message when a member leaves a guild.
-
-        Parameters:
-        -----------
-        event : interactions.Member
-            The member that left the guild.
-        """
+        """A listener that sends a message when a member leaves a guild."""
         logger.info("Member %s left the server %s", event.member.username, event.guild.name)
         if not is_guild_enabled(event.guild.id, enabled_servers):
             logger.info("Server not enabled")
@@ -112,9 +138,31 @@ class WelcomeExtension(Extension):
             "Au revoir **{mention}** !",
             mention=event.member.username,
         )
-        # Get the welcome channel
         channel = event.guild.get_channel(
             serv_config.get("welcomeChannelId") or event.guild.system_channel.id
         )
-        # Send the welcome message
-        await channel.send(filled_message)
+        files = await self._build_card_files(
+            event.member,
+            event.guild,
+            title="Au revoir",
+            enabled=serv_config.get("welcomeImageEnabled", True),
+        )
+        await channel.send(filled_message, files=files)
+
+    async def _build_card_files(
+        self, member, guild, *, title: str, enabled: bool
+    ) -> list[File]:
+        if not enabled:
+            return []
+        try:
+            avatar = await _fetch_avatar_bytes(member)
+            buffer = render_welcome_card(
+                avatar_bytes=avatar,
+                username=member.username,
+                title=title,
+                subtitle=_server_name_subtitle(guild.name, getattr(guild, "member_count", None)),
+            )
+            return [File(file=buffer, file_name="welcome.png")]
+        except Exception as e:
+            logger.warning("Could not render welcome card for %s: %s", member.username, e)
+            return []

--- a/extensions/welcome.py
+++ b/extensions/welcome.py
@@ -149,9 +149,7 @@ class WelcomeExtension(Extension):
         )
         await channel.send(filled_message, files=files)
 
-    async def _build_card_files(
-        self, member, guild, *, title: str, enabled: bool
-    ) -> list[File]:
+    async def _build_card_files(self, member, guild, *, title: str, enabled: bool) -> list[File]:
         if not enabled:
             return []
         try:

--- a/extensions/xp/__init__.py
+++ b/extensions/xp/__init__.py
@@ -21,9 +21,10 @@ from ._common import XpConfig, enabled_servers, logger, module_config
 from .commands import CommandsMixin
 from .leaderboard import LeaderboardMixin
 from .leveling import LevelingMixin
+from .voice import VoiceMixin
 
 
-class XpExtension(Extension, LevelingMixin, CommandsMixin, LeaderboardMixin):
+class XpExtension(Extension, LevelingMixin, VoiceMixin, CommandsMixin, LeaderboardMixin):
     """XP and leveling system extension."""
 
     def __init__(self, bot: Client):
@@ -32,6 +33,7 @@ class XpExtension(Extension, LevelingMixin, CommandsMixin, LeaderboardMixin):
         self._user_cache = TTLCache(ttl=USER_CACHE_TTL)
         self._rank_cache = TTLCache(ttl=RANK_CACHE_TTL)
         self._repos: dict[str, XpRepository] = {}
+        self._voice_sessions: dict[tuple[str, str], float] = {}
 
         self._validate_config()
         logger.debug("enabled_servers for XP module: %s", enabled_servers)
@@ -66,6 +68,7 @@ class XpExtension(Extension, LevelingMixin, CommandsMixin, LeaderboardMixin):
                 logger.error("Failed to create indexes for guild %s: %s", guild_id, e)
 
         self._cache_cleanup_task.start()
+        self._voice_xp_tick.start()
 
         self.leaderboardpermanent.start()
         await self.leaderboardpermanent()

--- a/extensions/xp/_common.py
+++ b/extensions/xp/_common.py
@@ -41,6 +41,28 @@ class XpConfig(SchemaBase):
         description="Épingler automatiquement le message du leaderboard.",
     )
     xpMessageId: str | None = hidden_message_id("Message leaderboard", "xpChannelId")
+    voiceXpEnabled: bool = ui(
+        "XP vocal",
+        "boolean",
+        default=False,
+        description="Octroyer de l'XP aux membres présents en salon vocal (par minute).",
+    )
+    levelRewards: dict[str, str] = ui(
+        "Récompenses par niveau",
+        "keyvaluemap",
+        description="Map niveau → ID de rôle attribué automatiquement à ce niveau.",
+        key_label="Niveau",
+        value_label="ID du rôle",
+    )
+    stackLevelRewards: bool = ui(
+        "Cumuler les rôles de niveau",
+        "boolean",
+        default=False,
+        description=(
+            "Si désactivé, le rôle de niveau précédent est retiré quand un palier "
+            "supérieur est franchi."
+        ),
+    )
     levelUpMessageList: list[str] = ui(
         "Messages de level-up",
         "messagelist",

--- a/extensions/xp/commands.py
+++ b/extensions/xp/commands.py
@@ -2,14 +2,53 @@
 
 from datetime import datetime
 
+import httpx
 import pymongo
-from interactions import Client, Embed, OptionType, SlashContext, User, slash_command, slash_option
+from interactions import (
+    Client,
+    Embed,
+    File,
+    OptionType,
+    SlashContext,
+    User,
+    slash_command,
+    slash_option,
+)
 
-from features.xp import TTLCache, XpRepository, calculate_level, create_progress_bar
+from features.xp import (
+    TTLCache,
+    XpRepository,
+    calculate_level,
+    create_progress_bar,
+    render_rank_card,
+)
 from src.discord_ext.messages import send_error
 from src.discord_ext.paginator import CustomPaginator
 
 from ._common import EMBED_COLOR, TIMEZONE, enabled_servers, logger
+
+
+async def _fetch_avatar_bytes(target_user) -> bytes | None:
+    avatar_url = (
+        getattr(target_user, "display_avatar", None)
+        or getattr(target_user, "avatar_url", None)
+    )
+    if avatar_url is None:
+        return None
+    url = str(avatar_url)
+    if "?" in url:
+        url = url.split("?", 1)[0]
+    if "." in url.rsplit("/", 1)[-1]:
+        url = url.rsplit(".", 1)[0] + ".png"
+    url = f"{url}?size=256"
+    try:
+        async with httpx.AsyncClient(timeout=8.0) as client:
+            response = await client.get(url)
+            response.raise_for_status()
+            return response.content
+    except Exception as e:
+        logger.debug("Could not fetch avatar for rank card: %s", e)
+        return None
 
 
 class CommandsMixin:
@@ -69,11 +108,32 @@ class CommandsMixin:
             await ctx.send(f"{target_user.mention} n'a pas encore de niveau.")
             return
 
+        await ctx.defer()
         xp = stats.get("xp", 0)
         lvl, xp_in_level, xp_max = calculate_level(xp)
         rank = await self._get_user_rank(guild_id, str(target_user.id))
-        rank_display = f"{rank}/{ctx.guild.member_count}" if rank else "N/A"
 
+        avatar_bytes = await _fetch_avatar_bytes(target_user)
+        try:
+            buffer = render_rank_card(
+                avatar_bytes=avatar_bytes,
+                username=target_user.username,
+                display_name=getattr(target_user, "display_name", target_user.username),
+                level=lvl,
+                xp_in_level=xp_in_level,
+                xp_to_next=xp_max,
+                total_xp=xp,
+                rank=rank,
+                member_count=ctx.guild.member_count,
+                message_count=stats.get("msg", 0),
+            )
+            await ctx.send(file=File(file=buffer, file_name="rank.png"))
+            return
+        except Exception as e:
+            logger.warning("Falling back to embed rank card: %s", e)
+
+        # Embed fallback when image rendering fails (e.g. missing fonts/Pillow).
+        rank_display = f"{rank}/{ctx.guild.member_count}" if rank else "N/A"
         embed = Embed(
             title=f"Statistiques de {target_user.username}",
             color=EMBED_COLOR,

--- a/extensions/xp/commands.py
+++ b/extensions/xp/commands.py
@@ -29,9 +29,8 @@ from ._common import EMBED_COLOR, TIMEZONE, enabled_servers, logger
 
 
 async def _fetch_avatar_bytes(target_user) -> bytes | None:
-    avatar_url = (
-        getattr(target_user, "display_avatar", None)
-        or getattr(target_user, "avatar_url", None)
+    avatar_url = getattr(target_user, "display_avatar", None) or getattr(
+        target_user, "avatar_url", None
     )
     if avatar_url is None:
         return None

--- a/extensions/xp/leveling.py
+++ b/extensions/xp/leveling.py
@@ -188,9 +188,7 @@ class LevelingMixin:
             return
 
         try:
-            await member.add_role(
-                new_role_id, reason=f"Récompense XP niveau {new_level}"
-            )
+            await member.add_role(new_role_id, reason=f"Récompense XP niveau {new_level}")
         except Exception as e:
             logger.warning(
                 "Could not grant level reward role %s to %s: %s",

--- a/extensions/xp/leveling.py
+++ b/extensions/xp/leveling.py
@@ -152,3 +152,70 @@ class LevelingMixin:
             lvl=new_level,
         )
         await message.channel.send(formatted_message)
+        await self._apply_level_rewards(guild_id, message.author, new_level)
+
+    async def _apply_level_rewards(self, guild_id: str, member, new_level: int) -> None:
+        """Grant the configured role for ``new_level`` (and optionally drop lower-tier roles).
+
+        Config shape (per guild)::
+
+            "levelRewards": {"5": "1234567890", "10": "9876543210", ...}
+            "stackLevelRewards": false    # drop the previous tier when set
+
+        Silent no-op when no reward matches or the bot lacks Manage Roles.
+        """
+        guild_config = module_config.get(guild_id, {})
+        rewards: dict = guild_config.get("levelRewards") or {}
+        if not rewards:
+            return
+
+        # Map int level → role id, ignoring malformed entries.
+        parsed: dict[int, int] = {}
+        for raw_level, raw_role in rewards.items():
+            try:
+                parsed[int(raw_level)] = int(raw_role)
+            except (TypeError, ValueError):
+                continue
+        if not parsed:
+            return
+
+        new_role_id = parsed.get(new_level)
+        if not new_role_id:
+            return
+
+        guild = getattr(member, "guild", None)
+        if guild is None:
+            return
+
+        try:
+            await member.add_role(
+                new_role_id, reason=f"Récompense XP niveau {new_level}"
+            )
+        except Exception as e:
+            logger.warning(
+                "Could not grant level reward role %s to %s: %s",
+                new_role_id,
+                member.id,
+                e,
+            )
+            return
+
+        if guild_config.get("stackLevelRewards", False):
+            return
+
+        member_role_ids = {int(r.id) for r in getattr(member, "roles", [])}
+        for level, role_id in parsed.items():
+            if level >= new_level:
+                continue
+            if role_id in member_role_ids and role_id != new_role_id:
+                try:
+                    await member.remove_role(
+                        role_id, reason=f"Remplacé par le rôle de niveau {new_level}"
+                    )
+                except Exception as e:
+                    logger.debug(
+                        "Could not remove obsolete level role %s from %s: %s",
+                        role_id,
+                        member.id,
+                        e,
+                    )

--- a/extensions/xp/voice.py
+++ b/extensions/xp/voice.py
@@ -1,0 +1,158 @@
+"""VoiceMixin — award XP for time spent in voice channels.
+
+Sessions are tracked in memory keyed by ``(guild_id, user_id)`` with the
+timestamp of the last award. Every ``VOICE_TICK_SECONDS`` the periodic task
+sweeps tracked sessions and awards a small XP amount, which keeps the database
+write rate bounded and naturally drops users who disconnect (their session is
+removed on the leave event).
+
+XP is only awarded when:
+- the channel is not the guild's AFK channel, and
+- the channel has at least one other non-bot member (to avoid solo farming).
+"""
+
+import random
+import time
+
+import pymongo
+from interactions import Client, IntervalTrigger, Task, listen
+from interactions.api.events import VoiceStateUpdate
+
+from features.xp import (
+    VOICE_TICK_SECONDS,
+    VOICE_XP_PER_TICK_MAX,
+    VOICE_XP_PER_TICK_MIN,
+    TTLCache,
+    XpRepository,
+    calculate_level,
+)
+from src.discord_ext.autocomplete import is_guild_enabled
+
+from ._common import enabled_servers, logger, module_config
+
+
+class VoiceMixin:
+    """Award XP per minute for active voice-channel presence."""
+
+    bot: Client
+    _db_connected: bool
+    _rank_cache: TTLCache
+    _repos: dict[str, XpRepository]
+    _voice_sessions: dict[tuple[str, str], float]  # (guild_id, user_id) -> last-award ts
+
+    def _repo(self, guild_id: str) -> XpRepository: ...  # provided by LevelingMixin
+    def _invalidate_rank_cache(self, guild_id: str) -> None: ...  # provided by LevelingMixin
+
+    async def _handle_level_up(
+        self, guild_id: str, user_id: str, new_level: int, message
+    ) -> None: ...  # provided by LevelingMixin
+
+    @listen()
+    async def on_voice_state_update(self, event: VoiceStateUpdate):
+        before = event.before
+        after = event.after
+        member = (after or before).member if (after or before) else None
+        if member is None or member.bot:
+            return
+        guild = member.guild
+        if guild is None or not is_guild_enabled(guild.id, enabled_servers):
+            return
+        guild_id = str(guild.id)
+        if not module_config.get(guild_id, {}).get("voiceXpEnabled", False):
+            return
+
+        key = (guild_id, str(member.id))
+        before_chan = before.channel if before else None
+        after_chan = after.channel if after else None
+
+        if after_chan is None and before_chan is not None:
+            self._voice_sessions.pop(key, None)
+        elif after_chan is not None and before_chan is None:
+            self._voice_sessions[key] = time.time()
+        # Channel switches (move) keep the session running.
+
+    @Task.create(IntervalTrigger(seconds=VOICE_TICK_SECONDS))
+    async def _voice_xp_tick(self):
+        if not getattr(self, "_db_connected", False):
+            return
+        now = time.time()
+        for key in list(self._voice_sessions.keys()):
+            await self._tick_voice_session(key, now)
+
+    async def _tick_voice_session(self, key: tuple[str, str], now: float) -> None:
+        guild_id, user_id = key
+        last = self._voice_sessions.get(key)
+        if last is None or now - last < VOICE_TICK_SECONDS:
+            return
+
+        guild = self.bot.get_guild(int(guild_id))
+        if guild is None:
+            self._voice_sessions.pop(key, None)
+            return
+        member = guild.get_member(int(user_id))
+        if member is None or member.voice is None or member.voice.channel is None:
+            self._voice_sessions.pop(key, None)
+            return
+
+        voice_channel = member.voice.channel
+        afk_channel_id = getattr(guild, "afk_channel_id", None)
+        if afk_channel_id and int(voice_channel.id) == int(afk_channel_id):
+            return  # don't reward AFK lurkers
+
+        # voice_members may be a property exposing current channel members; fall
+        # back to scanning all guild members if not present (older library).
+        members = getattr(voice_channel, "voice_members", None)
+        if members is None:
+            members = [
+                m
+                for m in guild.members
+                if getattr(m, "voice", None)
+                and getattr(m.voice, "channel", None)
+                and m.voice.channel.id == voice_channel.id
+            ]
+        non_bot_count = sum(1 for m in members if not getattr(m, "bot", False))
+        if non_bot_count < 2:
+            return  # solo in channel; don't award
+
+        xp_gained = random.randint(VOICE_XP_PER_TICK_MIN, VOICE_XP_PER_TICK_MAX)
+        repo = self._repo(guild_id)
+        try:
+            stats = await repo.get_user(user_id)
+            if stats is None:
+                await repo.insert_new_user(user_id, xp_gained, now)
+                self._invalidate_rank_cache(guild_id)
+                self._voice_sessions[key] = now
+                return
+            new_xp = stats.get("xp", 0) + xp_gained
+            new_msg = stats.get("msg", 0)
+            await repo.update_xp(user_id, new_xp, new_msg, now)
+            self._invalidate_rank_cache(guild_id)
+        except pymongo.errors.PyMongoError as e:
+            logger.error("Voice XP DB error for %s in %s: %s", user_id, guild_id, e)
+            return
+
+        self._voice_sessions[key] = now
+
+        new_level, _, _ = calculate_level(new_xp)
+        old_level = stats.get("lvl", 0)
+        if new_level > old_level:
+            # We don't have a "message" object here; pass the voice channel so
+            # the level-up handler can announce in the user's current channel.
+            await self._handle_voice_level_up(guild_id, user_id, new_level, voice_channel, member)
+
+    async def _handle_voice_level_up(
+        self, guild_id: str, user_id: str, new_level: int, voice_channel, member
+    ) -> None:
+        """Persist the new level and announce in a sensible place."""
+        await self._repo(guild_id).set_level(user_id, new_level)
+        announce = getattr(voice_channel, "send", None)
+        if announce is not None:
+            try:
+                await announce(
+                    f"Bravo {member.mention}, tu as atteint le niveau {new_level} (vocal) !"
+                )
+            except Exception as e:
+                logger.debug("Could not announce voice level-up: %s", e)
+        # Role rewards are applied by LevelingMixin via a shared helper resolved
+        # through the host class's MRO.
+        await self._apply_level_rewards(guild_id, member, new_level)  # type: ignore[attr-defined]

--- a/extensions/youtube.py
+++ b/extensions/youtube.py
@@ -23,25 +23,36 @@ class YoutubeConfig(SchemaBase):
 
     enabled: bool = enabled_field()
     ChannelId: str = ui(
-        "Salon notifications",
+        "Salon de notification",
         "channel",
         required=True,
-        description="Salon pour les notifications de nouvelles vidéos.",
+        description="Salon où sont publiées les notifications de nouvelles vidéos.",
     )
     youtubeChannelList: list[str] = ui(
-        "Chaînes YouTube",
+        "Chaînes YouTube suivies",
         "list",
         required=True,
         description=(
-            "Liste des handles YouTube à surveiller, configurables depuis le "
-            "dashboard. Format : @handle ou simplement le nom de chaîne."
+            "Liste des handles YouTube à surveiller (un par ligne). "
+            "Format accepté : `@handle` ou juste le handle. "
+            "Modifiable directement depuis le dashboard."
         ),
+    )
+    youtubeChannelLabels: dict[str, str] = ui(
+        "Libellés personnalisés",
+        "keyvaluemap",
+        description=(
+            "Optionnel : associe un nom d'affichage à chaque handle. "
+            "Utilisé dans les logs et messages."
+        ),
+        key_label="Handle",
+        value_label="Libellé",
     )
     youtubeIncludeShorts: bool = ui(
         "Notifier les Shorts",
         "boolean",
         default=False,
-        description="Inclure les vidéos de moins de 90 secondes (Shorts).",
+        description="Inclure les vidéos courtes (Shorts).",
     )
     youtubeIncludeLive: bool = ui(
         "Notifier les lives",
@@ -54,6 +65,24 @@ class YoutubeConfig(SchemaBase):
         "boolean",
         default=True,
         description="Inclure les vidéos longues classiques (VOD).",
+    )
+    youtubeShortMaxSeconds: int = ui(
+        "Seuil Short (secondes)",
+        "number",
+        default=90,
+        description=(
+            "Durée maximale (en secondes) en deçà de laquelle une vidéo est "
+            "considérée comme un Short. 90 par défaut."
+        ),
+    )
+    youtubeNotificationTemplate: str = ui(
+        "Modèle de notification",
+        "string",
+        default="https://www.youtube.com/watch?v={video_id}",
+        description=(
+            "Texte envoyé pour chaque nouvelle vidéo. Variables : "
+            "`{video_id}`, `{handle}`, `{label}`."
+        ),
     )
 
 
@@ -90,6 +119,10 @@ class YoutubeExtension(Extension):
                     server,
                 )
             filters = self._content_filters(srv_config)
+            template = srv_config.get(
+                "youtubeNotificationTemplate", "https://www.youtube.com/watch?v={video_id}"
+            )
+            labels: dict[str, str] = srv_config.get("youtubeChannelLabels") or {}
             for user in srv_config["youtubeChannelList"]:
                 if not user:
                     continue
@@ -101,16 +134,26 @@ class YoutubeExtension(Extension):
                     continue
                 youtube_data = self.update_youtube_data(server, user, video_id, youtube_data)
                 if not is_initial_sync and await self.is_video_valid(video_id, filters):
-                    await channel.send(f"https://www.youtube.com/watch?v={video_id}")
+                    label = labels.get(handle) or labels.get(user) or handle
+                    try:
+                        rendered = template.format(video_id=video_id, handle=handle, label=label)
+                    except (KeyError, IndexError):
+                        rendered = f"https://www.youtube.com/watch?v={video_id}"
+                    await channel.send(rendered)
             await self.save_youtube_data(youtube_data)
 
     @staticmethod
-    def _content_filters(srv_config: dict) -> dict[str, bool]:
+    def _content_filters(srv_config: dict) -> dict[str, object]:
         """Per-guild content filter dict consumed by ``is_video_valid``."""
+        try:
+            short_max = int(srv_config.get("youtubeShortMaxSeconds", 90))
+        except (TypeError, ValueError):
+            short_max = 90
         return {
             "shorts": bool(srv_config.get("youtubeIncludeShorts", False)),
             "live": bool(srv_config.get("youtubeIncludeLive", False)),
             "vod": bool(srv_config.get("youtubeIncludeVod", True)),
+            "short_max_seconds": max(1, short_max),
         }
 
     async def get_uploads(self, user):
@@ -151,14 +194,14 @@ class YoutubeExtension(Extension):
         youtube_data[str(server)][user] = video_id
         return youtube_data
 
-    async def is_video_valid(self, video_id, filters: dict[str, bool] | None = None):
+    async def is_video_valid(self, video_id, filters: dict[str, object] | None = None):
         """Decide whether to surface ``video_id`` based on per-guild filters.
 
-        ``filters`` keys: ``shorts``, ``live``, ``vod``. Default mirrors the
-        legacy behaviour (VOD-only).
+        ``filters`` keys: ``shorts``, ``live``, ``vod``, ``short_max_seconds``.
+        Default mirrors the legacy behaviour (VOD-only, 90 s short threshold).
         """
         if filters is None:
-            filters = {"shorts": False, "live": False, "vod": True}
+            filters = {"shorts": False, "live": False, "vod": True, "short_max_seconds": 90}
         url = f"{YOUTUBE_API_URL}/videos?part=snippet,contentDetails&id={video_id}&key={YOUTUBE_API_KEY}"
         data = await fetch(url, return_type="json")
         logger.debug(data)
@@ -171,7 +214,8 @@ class YoutubeExtension(Extension):
             return False
 
         duration = isodate.parse_duration(item["contentDetails"]["duration"])
-        is_short = duration <= datetime.timedelta(minutes=1, seconds=30)
+        threshold = datetime.timedelta(seconds=int(filters.get("short_max_seconds", 90)))
+        is_short = duration <= threshold
         if is_short:
             if filters["shorts"]:
                 return True

--- a/extensions/youtube.py
+++ b/extensions/youtube.py
@@ -49,10 +49,24 @@ class YoutubeConfig(SchemaBase):
         value_label="Libellé",
     )
     youtubeIncludeShorts: bool = ui(
-        "Notifier les Shorts",
+        "Shorts (défaut)",
         "boolean",
         default=False,
-        description="Inclure les vidéos courtes (Shorts).",
+        description=(
+            "Valeur par défaut pour inclure les Shorts. "
+            "Surchargeable par chaîne via « Shorts par chaîne »."
+        ),
+    )
+    youtubeShortsPerChannel: dict[str, str] = ui(
+        "Shorts par chaîne",
+        "keyvaluemap",
+        description=(
+            "Override par handle : `true` pour notifier les Shorts de cette "
+            "chaîne, `false` pour les ignorer. Une entrée absente utilise la "
+            "valeur par défaut ci-dessus."
+        ),
+        key_label="Handle",
+        value_label="true / false",
     )
     youtubeIncludeLive: bool = ui(
         "Notifier les lives",
@@ -118,7 +132,6 @@ class YoutubeExtension(Extension):
                     "Initial YouTube sync for server %s – skipping notifications",
                     server,
                 )
-            filters = self._content_filters(srv_config)
             template = srv_config.get(
                 "youtubeNotificationTemplate", "https://www.youtube.com/watch?v={video_id}"
             )
@@ -133,6 +146,7 @@ class YoutubeExtension(Extension):
                 if self.is_video_already_checked(server, user, video_id, youtube_data):
                     continue
                 youtube_data = self.update_youtube_data(server, user, video_id, youtube_data)
+                filters = self._content_filters(srv_config, handle)
                 if not is_initial_sync and await self.is_video_valid(video_id, filters):
                     label = labels.get(handle) or labels.get(user) or handle
                     try:
@@ -143,14 +157,28 @@ class YoutubeExtension(Extension):
             await self.save_youtube_data(youtube_data)
 
     @staticmethod
-    def _content_filters(srv_config: dict) -> dict[str, object]:
-        """Per-guild content filter dict consumed by ``is_video_valid``."""
+    def _content_filters(srv_config: dict, handle: str) -> dict[str, object]:
+        """Per-channel content filter dict consumed by ``is_video_valid``.
+
+        Falls back to the guild-wide defaults when the channel has no override.
+        """
         try:
             short_max = int(srv_config.get("youtubeShortMaxSeconds", 90))
         except (TypeError, ValueError):
             short_max = 90
+
+        shorts_default = bool(srv_config.get("youtubeIncludeShorts", False))
+        per_channel = srv_config.get("youtubeShortsPerChannel") or {}
+        # Accept either bare or @-prefixed keys so the operator's UI input matches
+        # whatever they typed in `youtubeChannelList`.
+        raw = per_channel.get(handle, per_channel.get(f"@{handle}"))
+        if raw is None:
+            shorts = shorts_default
+        else:
+            shorts = str(raw).strip().lower() in {"1", "true", "yes", "y", "oui", "on"}
+
         return {
-            "shorts": bool(srv_config.get("youtubeIncludeShorts", False)),
+            "shorts": shorts,
             "live": bool(srv_config.get("youtubeIncludeLive", False)),
             "vod": bool(srv_config.get("youtubeIncludeVod", True)),
             "short_max_seconds": max(1, short_max),

--- a/extensions/youtube.py
+++ b/extensions/youtube.py
@@ -32,7 +32,28 @@ class YoutubeConfig(SchemaBase):
         "Chaînes YouTube",
         "list",
         required=True,
-        description="Liste des noms de chaînes YouTube à surveiller.",
+        description=(
+            "Liste des handles YouTube à surveiller, configurables depuis le "
+            "dashboard. Format : @handle ou simplement le nom de chaîne."
+        ),
+    )
+    youtubeIncludeShorts: bool = ui(
+        "Notifier les Shorts",
+        "boolean",
+        default=False,
+        description="Inclure les vidéos de moins de 90 secondes (Shorts).",
+    )
+    youtubeIncludeLive: bool = ui(
+        "Notifier les lives",
+        "boolean",
+        default=False,
+        description="Inclure les diffusions en direct (live broadcasts).",
+    )
+    youtubeIncludeVod: bool = ui(
+        "Notifier les VOD",
+        "boolean",
+        default=True,
+        description="Inclure les vidéos longues classiques (VOD).",
     )
 
 
@@ -56,10 +77,9 @@ class YoutubeExtension(Extension):
     @Task.create(IntervalTrigger(minutes=5))
     async def check_youtube(self):
         for server in enabled_servers:
-            if module_config[str(server)].get("ChannelId"):
-                channel: BaseChannel = await self.bot.fetch_channel(
-                    module_config[str(server)].get("ChannelId")
-                )
+            srv_config = module_config[str(server)]
+            if srv_config.get("ChannelId"):
+                channel: BaseChannel = await self.bot.fetch_channel(srv_config.get("ChannelId"))
             else:
                 continue
             youtube_data = await self.get_youtube_data()
@@ -69,15 +89,29 @@ class YoutubeExtension(Extension):
                     "Initial YouTube sync for server %s – skipping notifications",
                     server,
                 )
-            for user in module_config[str(server)]["youtubeChannelList"]:
-                uploads = await self.get_uploads(user)
+            filters = self._content_filters(srv_config)
+            for user in srv_config["youtubeChannelList"]:
+                if not user:
+                    continue
+                # Strip leading "@" so @handle and bare handle both resolve.
+                handle = user.lstrip("@")
+                uploads = await self.get_uploads(handle)
                 video_id = await self.get_video_id(uploads)
                 if self.is_video_already_checked(server, user, video_id, youtube_data):
                     continue
                 youtube_data = self.update_youtube_data(server, user, video_id, youtube_data)
-                if not is_initial_sync and await self.is_video_valid(video_id):
+                if not is_initial_sync and await self.is_video_valid(video_id, filters):
                     await channel.send(f"https://www.youtube.com/watch?v={video_id}")
             await self.save_youtube_data(youtube_data)
+
+    @staticmethod
+    def _content_filters(srv_config: dict) -> dict[str, bool]:
+        """Per-guild content filter dict consumed by ``is_video_valid``."""
+        return {
+            "shorts": bool(srv_config.get("youtubeIncludeShorts", False)),
+            "live": bool(srv_config.get("youtubeIncludeLive", False)),
+            "vod": bool(srv_config.get("youtubeIncludeVod", True)),
+        }
 
     async def get_uploads(self, user):
         if user not in self.playlist_cache:
@@ -117,18 +151,35 @@ class YoutubeExtension(Extension):
         youtube_data[str(server)][user] = video_id
         return youtube_data
 
-    async def is_video_valid(self, video_id):
+    async def is_video_valid(self, video_id, filters: dict[str, bool] | None = None):
+        """Decide whether to surface ``video_id`` based on per-guild filters.
+
+        ``filters`` keys: ``shorts``, ``live``, ``vod``. Default mirrors the
+        legacy behaviour (VOD-only).
+        """
+        if filters is None:
+            filters = {"shorts": False, "live": False, "vod": True}
         url = f"{YOUTUBE_API_URL}/videos?part=snippet,contentDetails&id={video_id}&key={YOUTUBE_API_KEY}"
         data = await fetch(url, return_type="json")
         logger.debug(data)
-        if data["items"][0]["snippet"]["liveBroadcastContent"] == "none":
-            duration = isodate.parse_duration(data["items"][0]["contentDetails"]["duration"])
-            if duration > datetime.timedelta(minutes=1, seconds=30):
+        item = data["items"][0]
+        live_state = item["snippet"]["liveBroadcastContent"]
+        if live_state != "none":
+            if filters["live"]:
                 return True
-            else:
-                logger.info("New video is a Short")
-        else:
-            logger.info("New video is a live stream")
+            logger.info("New video is a live stream — skipped (live filter off)")
+            return False
+
+        duration = isodate.parse_duration(item["contentDetails"]["duration"])
+        is_short = duration <= datetime.timedelta(minutes=1, seconds=30)
+        if is_short:
+            if filters["shorts"]:
+                return True
+            logger.info("New video is a Short — skipped (shorts filter off)")
+            return False
+        if filters["vod"]:
+            return True
+        logger.info("New video is a VOD — skipped (vod filter off)")
         return False
 
     async def save_youtube_data(self, youtube_data):

--- a/extensions/youtube.py
+++ b/extensions/youtube.py
@@ -28,57 +28,15 @@ class YoutubeConfig(SchemaBase):
         required=True,
         description="Salon où sont publiées les notifications de nouvelles vidéos.",
     )
-    youtubeChannelList: list[str] = ui(
+    youtubeChannelList: dict[str, dict] = ui(
         "Chaînes YouTube suivies",
-        "list",
+        "youtubechannelmap",
         required=True,
         description=(
-            "Liste des handles YouTube à surveiller (un par ligne). "
-            "Format accepté : `@handle` ou juste le handle. "
-            "Modifiable directement depuis le dashboard."
+            "Une ligne par chaîne avec ses propres bascules Shorts / Lives / "
+            "VOD. Le handle accepte `@handle` ou juste le handle ; un libellé "
+            "optionnel apparaît dans les logs et les notifications."
         ),
-    )
-    youtubeChannelLabels: dict[str, str] = ui(
-        "Libellés personnalisés",
-        "keyvaluemap",
-        description=(
-            "Optionnel : associe un nom d'affichage à chaque handle. "
-            "Utilisé dans les logs et messages."
-        ),
-        key_label="Handle",
-        value_label="Libellé",
-    )
-    youtubeIncludeShorts: bool = ui(
-        "Shorts (défaut)",
-        "boolean",
-        default=False,
-        description=(
-            "Valeur par défaut pour inclure les Shorts. "
-            "Surchargeable par chaîne via « Shorts par chaîne »."
-        ),
-    )
-    youtubeShortsPerChannel: dict[str, str] = ui(
-        "Shorts par chaîne",
-        "keyvaluemap",
-        description=(
-            "Override par handle : `true` pour notifier les Shorts de cette "
-            "chaîne, `false` pour les ignorer. Une entrée absente utilise la "
-            "valeur par défaut ci-dessus."
-        ),
-        key_label="Handle",
-        value_label="true / false",
-    )
-    youtubeIncludeLive: bool = ui(
-        "Notifier les lives",
-        "boolean",
-        default=False,
-        description="Inclure les diffusions en direct (live broadcasts).",
-    )
-    youtubeIncludeVod: bool = ui(
-        "Notifier les VOD",
-        "boolean",
-        default=True,
-        description="Inclure les vidéos longues classiques (VOD).",
     )
     youtubeShortMaxSeconds: int = ui(
         "Seuil Short (secondes)",
@@ -135,20 +93,29 @@ class YoutubeExtension(Extension):
             template = srv_config.get(
                 "youtubeNotificationTemplate", "https://www.youtube.com/watch?v={video_id}"
             )
-            labels: dict[str, str] = srv_config.get("youtubeChannelLabels") or {}
-            for user in srv_config["youtubeChannelList"]:
-                if not user:
+            try:
+                short_max = int(srv_config.get("youtubeShortMaxSeconds", 90))
+            except (TypeError, ValueError):
+                short_max = 90
+            short_max = max(1, short_max)
+
+            for raw_handle, channel_cfg in self._iter_channels(srv_config):
+                if not raw_handle:
                     continue
-                # Strip leading "@" so @handle and bare handle both resolve.
-                handle = user.lstrip("@")
+                handle = raw_handle.lstrip("@")
                 uploads = await self.get_uploads(handle)
                 video_id = await self.get_video_id(uploads)
-                if self.is_video_already_checked(server, user, video_id, youtube_data):
+                if self.is_video_already_checked(server, raw_handle, video_id, youtube_data):
                     continue
-                youtube_data = self.update_youtube_data(server, user, video_id, youtube_data)
-                filters = self._content_filters(srv_config, handle)
+                youtube_data = self.update_youtube_data(server, raw_handle, video_id, youtube_data)
+                filters = {
+                    "shorts": bool(channel_cfg.get("shorts", False)),
+                    "live": bool(channel_cfg.get("live", False)),
+                    "vod": bool(channel_cfg.get("vod", True)),
+                    "short_max_seconds": short_max,
+                }
                 if not is_initial_sync and await self.is_video_valid(video_id, filters):
-                    label = labels.get(handle) or labels.get(user) or handle
+                    label = channel_cfg.get("label") or handle
                     try:
                         rendered = template.format(video_id=video_id, handle=handle, label=label)
                     except (KeyError, IndexError):
@@ -157,32 +124,20 @@ class YoutubeExtension(Extension):
             await self.save_youtube_data(youtube_data)
 
     @staticmethod
-    def _content_filters(srv_config: dict, handle: str) -> dict[str, object]:
-        """Per-channel content filter dict consumed by ``is_video_valid``.
+    def _iter_channels(srv_config: dict):
+        """Yield ``(handle, channel_cfg)`` pairs from the configured channel list.
 
-        Falls back to the guild-wide defaults when the channel has no override.
+        Accepts both the structured dict shape (``youtubechannelmap``) and the
+        legacy ``list[str]`` shape — list entries default to VOD-only with
+        Shorts and Lives disabled, matching the previous behaviour.
         """
-        try:
-            short_max = int(srv_config.get("youtubeShortMaxSeconds", 90))
-        except (TypeError, ValueError):
-            short_max = 90
-
-        shorts_default = bool(srv_config.get("youtubeIncludeShorts", False))
-        per_channel = srv_config.get("youtubeShortsPerChannel") or {}
-        # Accept either bare or @-prefixed keys so the operator's UI input matches
-        # whatever they typed in `youtubeChannelList`.
-        raw = per_channel.get(handle, per_channel.get(f"@{handle}"))
-        if raw is None:
-            shorts = shorts_default
-        else:
-            shorts = str(raw).strip().lower() in {"1", "true", "yes", "y", "oui", "on"}
-
-        return {
-            "shorts": shorts,
-            "live": bool(srv_config.get("youtubeIncludeLive", False)),
-            "vod": bool(srv_config.get("youtubeIncludeVod", True)),
-            "short_max_seconds": max(1, short_max),
-        }
+        raw = srv_config.get("youtubeChannelList")
+        if isinstance(raw, dict):
+            for handle, cfg in raw.items():
+                yield handle, (cfg if isinstance(cfg, dict) else {})
+        elif isinstance(raw, list):
+            for handle in raw:
+                yield handle, {"shorts": False, "live": False, "vod": True}
 
     async def get_uploads(self, user):
         if user not in self.playlist_cache:

--- a/features/polls/__init__.py
+++ b/features/polls/__init__.py
@@ -10,12 +10,27 @@ from features.polls.helpers import (
     parse_poll_author_id,
     validate_poll_options,
 )
+from features.polls.models import Poll, PollMode
+from features.polls.repository import PollRepository
+from features.polls.tally import (
+    parse_duration,
+    render_bar,
+    tally_first_past_post,
+    tally_ranked_choice,
+)
 
 __all__ = [
     "DEFAULT_POLL_EMOJIS",
     "DEFAULT_POLL_OPTIONS",
     "MAX_POLL_OPTIONS",
     "POLL_EMOJIS",
+    "Poll",
+    "PollMode",
+    "PollRepository",
+    "parse_duration",
     "parse_poll_author_id",
+    "render_bar",
+    "tally_first_past_post",
+    "tally_ranked_choice",
     "validate_poll_options",
 ]

--- a/features/polls/models.py
+++ b/features/polls/models.py
@@ -1,0 +1,30 @@
+"""Pydantic models for the polls feature (button-based and ranked polls)."""
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+PollMode = Literal["public", "anonymous", "ranked"]
+
+
+class Poll(BaseModel):
+    """A button-based poll persisted to MongoDB.
+
+    ``votes`` maps Discord user IDs to a list of option indices:
+    - public/anonymous: a one-element list (the chosen option)
+    - ranked: ordered preference list (first item = top choice)
+    """
+
+    id: str | None = Field(default=None, alias="_id")
+    channel_id: str
+    message_id: str
+    author_id: str
+    question: str
+    options: list[str]
+    mode: PollMode = "public"
+    closes_at: datetime | None = None
+    closed: bool = False
+    votes: dict[str, list[int]] = Field(default_factory=dict)
+
+    model_config = {"populate_by_name": True}

--- a/features/polls/repository.py
+++ b/features/polls/repository.py
@@ -1,0 +1,90 @@
+"""MongoDB I/O for the button-based polls feature."""
+
+import os
+from datetime import datetime
+
+import pymongo
+from bson import ObjectId
+
+from features.polls.models import Poll
+from src.core.db import mongo_manager
+from src.core.errors import DatabaseError
+from src.core.logging import init_logger
+
+logger = init_logger(os.path.basename(__file__))
+
+COLLECTION = "polls"
+
+
+class PollRepository:
+    """Per-guild store for button-based polls."""
+
+    def __init__(self, guild_id: str | int) -> None:
+        self._guild_id = str(guild_id)
+
+    def _col(self):
+        return mongo_manager.get_guild_collection(self._guild_id, COLLECTION)
+
+    async def ensure_indexes(self) -> None:
+        try:
+            await self._col().create_index(
+                [("message_id", pymongo.ASCENDING)], name="message_id_idx", unique=True
+            )
+            await self._col().create_index(
+                [("closed", pymongo.ASCENDING), ("closes_at", pymongo.ASCENDING)],
+                name="closes_at_idx",
+            )
+        except Exception as e:
+            logger.error("Failed to create poll indexes for guild %s: %s", self._guild_id, e)
+
+    @staticmethod
+    def _doc_to_poll(doc: dict) -> Poll:
+        doc = dict(doc)
+        if "_id" in doc:
+            doc["_id"] = str(doc["_id"])
+        return Poll(**doc)
+
+    async def add(self, poll: Poll) -> str:
+        try:
+            payload = poll.model_dump(exclude={"id"})
+            result = await self._col().insert_one(payload)
+            return str(result.inserted_id)
+        except Exception as e:
+            logger.error("DB insert_one failed: %s", e)
+            raise DatabaseError(f"Failed to add poll: {e}") from e
+
+    async def get_by_message(self, message_id: str) -> Poll | None:
+        doc = await self._col().find_one({"message_id": str(message_id)})
+        return self._doc_to_poll(doc) if doc else None
+
+    async def set_vote(self, poll_id: str, user_id: str, ranking: list[int]) -> None:
+        try:
+            await self._col().update_one(
+                {"_id": ObjectId(poll_id)},
+                {"$set": {f"votes.{user_id}": ranking}},
+            )
+        except Exception as e:
+            logger.error("DB update_one failed: %s", e)
+            raise DatabaseError(f"Failed to record vote: {e}") from e
+
+    async def clear_vote(self, poll_id: str, user_id: str) -> None:
+        try:
+            await self._col().update_one(
+                {"_id": ObjectId(poll_id)},
+                {"$unset": {f"votes.{user_id}": ""}},
+            )
+        except Exception as e:
+            logger.error("DB update_one failed: %s", e)
+            raise DatabaseError(f"Failed to clear vote: {e}") from e
+
+    async def list_due(self, now: datetime) -> list[Poll]:
+        cursor = self._col().find(
+            {"closed": False, "closes_at": {"$ne": None, "$lte": now}}
+        )
+        docs = await cursor.to_list(length=None)
+        return [self._doc_to_poll(d) for d in docs]
+
+    async def mark_closed(self, poll_id: str) -> None:
+        await self._col().update_one(
+            {"_id": ObjectId(poll_id)}, {"$set": {"closed": True}}
+        )

--- a/features/polls/repository.py
+++ b/features/polls/repository.py
@@ -78,13 +78,9 @@ class PollRepository:
             raise DatabaseError(f"Failed to clear vote: {e}") from e
 
     async def list_due(self, now: datetime) -> list[Poll]:
-        cursor = self._col().find(
-            {"closed": False, "closes_at": {"$ne": None, "$lte": now}}
-        )
+        cursor = self._col().find({"closed": False, "closes_at": {"$ne": None, "$lte": now}})
         docs = await cursor.to_list(length=None)
         return [self._doc_to_poll(d) for d in docs]
 
     async def mark_closed(self, poll_id: str) -> None:
-        await self._col().update_one(
-            {"_id": ObjectId(poll_id)}, {"$set": {"closed": True}}
-        )
+        await self._col().update_one({"_id": ObjectId(poll_id)}, {"$set": {"closed": True}})

--- a/features/polls/tally.py
+++ b/features/polls/tally.py
@@ -1,0 +1,161 @@
+"""Pure tally helpers — first-past-the-post and instant-runoff voting."""
+
+
+def tally_first_past_post(
+    votes: dict[str, list[int]], num_options: int
+) -> list[int]:
+    """Return per-option vote counts. ``votes`` values use only their first index."""
+    counts = [0] * num_options
+    for ranking in votes.values():
+        if ranking and 0 <= ranking[0] < num_options:
+            counts[ranking[0]] += 1
+    return counts
+
+
+def tally_ranked_choice(
+    votes: dict[str, list[int]], num_options: int
+) -> tuple[list[list[int]], int | None]:
+    """Run instant-runoff voting (IRV).
+
+    Returns ``(rounds, winner)`` where ``rounds`` is a list of per-round vote
+    counts (one entry per option, ``0`` for eliminated options) and ``winner``
+    is the index of the winning option (``None`` if no votes were cast).
+
+    Tie-breaking on elimination: drops the lowest-indexed option among the
+    smallest. Stops early if a candidate holds a strict majority of remaining
+    ballots.
+    """
+    if not votes or num_options <= 0:
+        return [], None
+
+    # Filter rankings to valid indices, dedup within each ballot.
+    ballots: list[list[int]] = []
+    for ranking in votes.values():
+        seen: set[int] = set()
+        cleaned = []
+        for idx in ranking:
+            if 0 <= idx < num_options and idx not in seen:
+                seen.add(idx)
+                cleaned.append(idx)
+        if cleaned:
+            ballots.append(cleaned)
+
+    if not ballots:
+        return [], None
+
+    eliminated: set[int] = set()
+    rounds: list[list[int]] = []
+
+    while True:
+        counts = [0] * num_options
+        for ballot in ballots:
+            for choice in ballot:
+                if choice not in eliminated:
+                    counts[choice] += 1
+                    break
+        rounds.append(counts.copy())
+
+        active_total = sum(counts)
+        if active_total == 0:
+            return rounds, None
+
+        # Majority winner?
+        max_count = max(counts)
+        if max_count * 2 > active_total:
+            return rounds, counts.index(max_count)
+
+        # Eliminate the lowest non-zero candidate(s); if all remaining are tied,
+        # return the first-indexed remaining option.
+        active_counts = [
+            (i, c) for i, c in enumerate(counts) if i not in eliminated and c > 0
+        ]
+        if not active_counts:
+            return rounds, None
+        if len({c for _, c in active_counts}) == 1:
+            # Perfect tie — return earliest option still standing.
+            return rounds, active_counts[0][0]
+
+        min_count = min(c for _, c in active_counts)
+        for i, c in active_counts:
+            if c == min_count:
+                eliminated.add(i)
+                break  # eliminate one per round to stay deterministic
+
+
+def render_bar(count: int, total: int, length: int = 12) -> str:
+    """Render a unicode progress bar of ``length`` cells based on ``count/total``."""
+    if total <= 0:
+        return "▱" * length
+    filled = round(count / total * length)
+    filled = max(0, min(filled, length))
+    return "▰" * filled + "▱" * (length - filled)
+
+
+def parse_duration(text: str) -> int | None:
+    """Parse a duration string like ``"30m"``, ``"2h"``, ``"1d"``, ``"45"``.
+
+    Returns total seconds or ``None`` on malformed input. Bare numbers are
+    minutes for backwards-friendliness with the slash-command UX.
+    """
+    if not text:
+        return None
+    text = text.strip().lower()
+    multipliers = {"s": 1, "m": 60, "h": 3600, "d": 86400}
+    total = 0
+    current = ""
+    for ch in text:
+        if ch.isdigit():
+            current += ch
+            continue
+        if ch in multipliers and current:
+            total += int(current) * multipliers[ch]
+            current = ""
+            continue
+        return None
+    if current:
+        total += int(current) * 60  # bare number → minutes
+    return total if total > 0 else None
+
+
+__all__ = [
+    "parse_duration",
+    "render_bar",
+    "tally_first_past_post",
+    "tally_ranked_choice",
+]
+
+
+# Light sanity tests so behavior is documented in source.
+if __name__ == "__main__":
+    # Plurality: option 0 wins
+    counts = tally_first_past_post(
+        {"a": [0], "b": [0], "c": [1]}, num_options=3
+    )
+    assert counts == [2, 1, 0], counts
+
+    # Ranked: A wins outright with majority of first-choice votes.
+    rounds, winner = tally_ranked_choice(
+        {"a": [0, 1], "b": [0, 2], "c": [1, 0], "d": [1, 0], "e": [0, 1]}, 3
+    )
+    assert winner == 0, (rounds, winner)
+
+    # Ranked: requires runoff. 2-2-1 -> eliminate 2 -> redistribute.
+    rounds, winner = tally_ranked_choice(
+        {
+            "a": [0, 2],
+            "b": [0, 2],
+            "c": [1, 2],
+            "d": [1, 2],
+            "e": [2, 0],
+        },
+        3,
+    )
+    # After eliminating option 2 (count 1), e's vote moves to 0 → 0 wins 3-2.
+    assert winner == 0, (rounds, winner)
+
+    assert parse_duration("30m") == 1800
+    assert parse_duration("2h") == 7200
+    assert parse_duration("1d") == 86400
+    assert parse_duration("90") == 5400
+    assert parse_duration("bad") is None
+    print("polls.tally self-tests passed")

--- a/features/polls/tally.py
+++ b/features/polls/tally.py
@@ -1,9 +1,7 @@
 """Pure tally helpers — first-past-the-post and instant-runoff voting."""
 
 
-def tally_first_past_post(
-    votes: dict[str, list[int]], num_options: int
-) -> list[int]:
+def tally_first_past_post(votes: dict[str, list[int]], num_options: int) -> list[int]:
     """Return per-option vote counts. ``votes`` values use only their first index."""
     counts = [0] * num_options
     for ranking in votes.values():
@@ -66,9 +64,7 @@ def tally_ranked_choice(
 
         # Eliminate the lowest non-zero candidate(s); if all remaining are tied,
         # return the first-indexed remaining option.
-        active_counts = [
-            (i, c) for i, c in enumerate(counts) if i not in eliminated and c > 0
-        ]
+        active_counts = [(i, c) for i, c in enumerate(counts) if i not in eliminated and c > 0]
         if not active_counts:
             return rounds, None
         if len({c for _, c in active_counts}) == 1:
@@ -128,9 +124,7 @@ __all__ = [
 # Light sanity tests so behavior is documented in source.
 if __name__ == "__main__":
     # Plurality: option 0 wins
-    counts = tally_first_past_post(
-        {"a": [0], "b": [0], "c": [1]}, num_options=3
-    )
+    counts = tally_first_past_post({"a": [0], "b": [0], "c": [1]}, num_options=3)
     assert counts == [2, 1, 0], counts
 
     # Ranked: A wins outright with majority of first-choice votes.

--- a/features/reminders/models.py
+++ b/features/reminders/models.py
@@ -9,12 +9,31 @@ Frequency = Literal["daily", "weekly", "monthly", "yearly"]
 
 
 class Reminder(BaseModel):
-    """A single scheduled reminder for one user."""
+    """A single scheduled reminder.
+
+    ``user_id`` is the author/creator. ``recipient_ids`` enables shared/group
+    reminders: every listed Discord user is DM'd when the reminder fires.
+    Empty/missing ``recipient_ids`` means "DM the author only" — the legacy
+    behaviour, preserved for documents written before this field existed.
+    """
 
     id: str | None = Field(default=None, alias="_id")
     user_id: str
     message: str
     remind_time: datetime
     frequency: Frequency | None = None
+    recipient_ids: list[str] = Field(default_factory=list)
 
     model_config = {"populate_by_name": True}
+
+    def all_recipients(self) -> list[str]:
+        """Recipients for this reminder, always including the author."""
+        if not self.recipient_ids:
+            return [self.user_id]
+        unique: list[str] = []
+        seen: set[str] = set()
+        for uid in (self.user_id, *self.recipient_ids):
+            if uid and uid not in seen:
+                seen.add(uid)
+                unique.append(uid)
+        return unique

--- a/features/tricount/__init__.py
+++ b/features/tricount/__init__.py
@@ -1,0 +1,5 @@
+"""Tricount feature — chart rendering and recurring-expense helpers."""
+
+from features.tricount.charts import render_category_chart
+
+__all__ = ["render_category_chart"]

--- a/features/tricount/charts.py
+++ b/features/tricount/charts.py
@@ -1,0 +1,107 @@
+"""Pillow-based bar chart renderer for tricount expense breakdowns."""
+
+from __future__ import annotations
+
+from io import BytesIO
+from pathlib import Path
+
+from PIL import Image, ImageDraw, ImageFont
+
+_FONT_PATH = str(Path(__file__).resolve().parent.parent.parent / "src" / "assets" / "OpenSans.ttf")
+
+_BG = (24, 25, 28)
+_PANEL = (35, 37, 41)
+_GRID = (60, 62, 68)
+_TEXT_PRIMARY = (242, 243, 245)
+_TEXT_DIM = (170, 175, 185)
+
+_BAR_PALETTE = [
+    (88, 196, 132),
+    (90, 110, 230),
+    (230, 110, 90),
+    (200, 160, 80),
+    (180, 90, 200),
+    (90, 200, 200),
+    (230, 90, 150),
+    (140, 230, 90),
+]
+
+
+def render_category_chart(
+    *,
+    title: str,
+    category_totals: dict[str, float],
+    currency: str = "€",
+) -> BytesIO:
+    """Render a horizontal bar chart of spending per category. PNG ``BytesIO``.
+
+    Empty input is rendered as a single "No data" placeholder.
+    """
+    items = sorted(category_totals.items(), key=lambda x: x[1], reverse=True)
+    width = 900
+    row_height = 44
+    header_height = 90
+    footer_height = 30
+    height = max(180, header_height + footer_height + max(1, len(items)) * row_height + 20)
+
+    img = Image.new("RGB", (width, height), _BG)
+    draw = ImageDraw.Draw(img)
+    draw.rounded_rectangle((10, 10, width - 10, height - 10), radius=18, fill=_PANEL)
+
+    title_font = ImageFont.truetype(_FONT_PATH, 28)
+    label_font = ImageFont.truetype(_FONT_PATH, 20)
+    value_font = ImageFont.truetype(_FONT_PATH, 18)
+
+    draw.text((30, 28), title, font=title_font, fill=_TEXT_PRIMARY)
+    total = sum(v for _, v in items)
+    draw.text(
+        (30, 62),
+        f"Total : {total:.2f}{currency}" if total else "Aucune donnée",
+        font=value_font,
+        fill=_TEXT_DIM,
+    )
+
+    if not items:
+        return _to_buffer(img)
+
+    label_w = 200
+    bar_x = 30 + label_w + 10
+    bar_max_w = width - bar_x - 30
+    max_value = max(v for _, v in items) or 1.0
+
+    for i, (label, value) in enumerate(items):
+        y = header_height + i * row_height
+        # Truncate long category labels to keep alignment.
+        text_label = label if len(label) <= 22 else label[:21] + "…"
+        draw.text((30, y + 6), text_label, font=label_font, fill=_TEXT_PRIMARY)
+
+        # Background bar (full width, faded).
+        draw.rounded_rectangle(
+            (bar_x, y + 8, bar_x + bar_max_w, y + 32), radius=12, fill=_GRID
+        )
+        # Filled portion.
+        bar_w = max(int(bar_max_w * (value / max_value)), 6)
+        color = _BAR_PALETTE[i % len(_BAR_PALETTE)]
+        draw.rounded_rectangle(
+            (bar_x, y + 8, bar_x + bar_w, y + 32), radius=12, fill=color
+        )
+        pct = (value / total * 100) if total else 0
+        value_text = f"{value:.2f}{currency} ({pct:.0f}%)"
+        draw.text(
+            (bar_x + bar_w + 8, y + 9),
+            value_text,
+            font=value_font,
+            fill=_TEXT_DIM,
+        )
+
+    return _to_buffer(img)
+
+
+def _to_buffer(img: Image.Image) -> BytesIO:
+    buf = BytesIO()
+    img.save(buf, format="PNG")
+    buf.seek(0)
+    return buf
+
+
+__all__ = ["render_category_chart"]

--- a/features/tricount/charts.py
+++ b/features/tricount/charts.py
@@ -76,15 +76,11 @@ def render_category_chart(
         draw.text((30, y + 6), text_label, font=label_font, fill=_TEXT_PRIMARY)
 
         # Background bar (full width, faded).
-        draw.rounded_rectangle(
-            (bar_x, y + 8, bar_x + bar_max_w, y + 32), radius=12, fill=_GRID
-        )
+        draw.rounded_rectangle((bar_x, y + 8, bar_x + bar_max_w, y + 32), radius=12, fill=_GRID)
         # Filled portion.
         bar_w = max(int(bar_max_w * (value / max_value)), 6)
         color = _BAR_PALETTE[i % len(_BAR_PALETTE)]
-        draw.rounded_rectangle(
-            (bar_x, y + 8, bar_x + bar_w, y + 32), radius=12, fill=color
-        )
+        draw.rounded_rectangle((bar_x, y + 8, bar_x + bar_w, y + 32), radius=12, fill=color)
         pct = (value / total * 100) if total else 0
         value_text = f"{value:.2f}{currency} ({pct:.0f}%)"
         draw.text(

--- a/features/welcome/__init__.py
+++ b/features/welcome/__init__.py
@@ -1,0 +1,5 @@
+"""Welcome feature — image-card renderer for join/leave events."""
+
+from features.welcome.card import render_welcome_card
+
+__all__ = ["render_welcome_card"]

--- a/features/welcome/card.py
+++ b/features/welcome/card.py
@@ -1,0 +1,98 @@
+"""Render a welcome/leave card image with the member's avatar and name."""
+
+from __future__ import annotations
+
+from io import BytesIO
+from pathlib import Path
+
+from PIL import Image, ImageDraw, ImageFilter, ImageFont
+
+_FONT_PATH = str(Path(__file__).resolve().parent.parent.parent / "src" / "assets" / "OpenSans.ttf")
+
+CARD_WIDTH = 800
+CARD_HEIGHT = 250
+AVATAR_SIZE = 160
+PADDING = 32
+
+_BG_COLOR = (30, 31, 34)
+_ACCENT_COLOR = (90, 110, 230)
+_TEXT_PRIMARY = (242, 243, 245)
+_TEXT_SECONDARY = (170, 175, 185)
+
+
+def _circular_avatar(avatar_bytes: bytes, size: int) -> Image.Image:
+    """Crop an avatar to a circle of *size* pixels."""
+    img = Image.open(BytesIO(avatar_bytes)).convert("RGBA").resize((size, size))
+    mask = Image.new("L", (size, size), 0)
+    ImageDraw.Draw(mask).ellipse((0, 0, size, size), fill=255)
+    out = Image.new("RGBA", (size, size), (0, 0, 0, 0))
+    out.paste(img, (0, 0), mask=mask)
+    return out
+
+
+def render_welcome_card(
+    *,
+    avatar_bytes: bytes | None,
+    username: str,
+    title: str = "Bienvenue",
+    subtitle: str | None = None,
+) -> BytesIO:
+    """Render a 800×250 welcome card. Returns a PNG ``BytesIO`` ready to upload.
+
+    ``avatar_bytes`` should be the raw bytes of the user's avatar (PNG/JPEG/GIF
+    first frame). When None, the avatar circle is left empty.
+    """
+    card = Image.new("RGB", (CARD_WIDTH, CARD_HEIGHT), _BG_COLOR)
+    draw = ImageDraw.Draw(card)
+
+    # Soft accent glow behind where the avatar will sit.
+    glow_size = AVATAR_SIZE + 60
+    glow_x = PADDING + (AVATAR_SIZE // 2) - (glow_size // 2)
+    glow_y = (CARD_HEIGHT // 2) - (glow_size // 2)
+    glow = Image.new("RGBA", (glow_size, glow_size), (0, 0, 0, 0))
+    ImageDraw.Draw(glow).ellipse(
+        (0, 0, glow_size, glow_size), fill=(*_ACCENT_COLOR, 90)
+    )
+    glow = glow.filter(ImageFilter.GaussianBlur(20))
+    card.paste(glow, (glow_x, glow_y), glow)
+
+    # Avatar circle (or placeholder).
+    avatar_x = PADDING
+    avatar_y = (CARD_HEIGHT - AVATAR_SIZE) // 2
+    if avatar_bytes:
+        try:
+            avatar = _circular_avatar(avatar_bytes, AVATAR_SIZE)
+            card.paste(avatar, (avatar_x, avatar_y), avatar)
+        except Exception:
+            draw.ellipse(
+                (avatar_x, avatar_y, avatar_x + AVATAR_SIZE, avatar_y + AVATAR_SIZE),
+                fill=_ACCENT_COLOR,
+            )
+    else:
+        draw.ellipse(
+            (avatar_x, avatar_y, avatar_x + AVATAR_SIZE, avatar_y + AVATAR_SIZE),
+            fill=_ACCENT_COLOR,
+        )
+
+    # Text block right of the avatar.
+    text_x = PADDING + AVATAR_SIZE + PADDING
+    title_font = ImageFont.truetype(_FONT_PATH, 36)
+    name_font = ImageFont.truetype(_FONT_PATH, 44)
+    sub_font = ImageFont.truetype(_FONT_PATH, 22)
+
+    draw.text((text_x, PADDING + 10), title, font=title_font, fill=_ACCENT_COLOR)
+
+    # Truncate over-long usernames so the layout stays readable.
+    display = username if len(username) <= 22 else username[:21] + "…"
+    draw.text((text_x, PADDING + 60), display, font=name_font, fill=_TEXT_PRIMARY)
+
+    if subtitle:
+        draw.text((text_x, PADDING + 130), subtitle, font=sub_font, fill=_TEXT_SECONDARY)
+
+    buffer = BytesIO()
+    card.save(buffer, format="PNG")
+    buffer.seek(0)
+    return buffer
+
+
+__all__ = ["render_welcome_card"]

--- a/features/welcome/card.py
+++ b/features/welcome/card.py
@@ -50,9 +50,7 @@ def render_welcome_card(
     glow_x = PADDING + (AVATAR_SIZE // 2) - (glow_size // 2)
     glow_y = (CARD_HEIGHT // 2) - (glow_size // 2)
     glow = Image.new("RGBA", (glow_size, glow_size), (0, 0, 0, 0))
-    ImageDraw.Draw(glow).ellipse(
-        (0, 0, glow_size, glow_size), fill=(*_ACCENT_COLOR, 90)
-    )
+    ImageDraw.Draw(glow).ellipse((0, 0, glow_size, glow_size), fill=(*_ACCENT_COLOR, 90))
     glow = glow.filter(ImageFilter.GaussianBlur(20))
     card.paste(glow, (glow_x, glow_y), glow)
 

--- a/features/xp/__init__.py
+++ b/features/xp/__init__.py
@@ -1,12 +1,16 @@
 """XP feature — level curve, leaderboard ranking, and MongoDB persistence."""
 
 from features.xp.cache import TTLCache
+from features.xp.card import render_rank_card
 from features.xp.constants import (
     DEFAULT_LEVEL_UP_MESSAGE,
     LEADERBOARD_PAGE_SIZE,
     RANK_CACHE_TTL,
     RANK_MEDALS,
     USER_CACHE_TTL,
+    VOICE_TICK_SECONDS,
+    VOICE_XP_PER_TICK_MAX,
+    VOICE_XP_PER_TICK_MIN,
     XP_COOLDOWN_SECONDS,
     XP_MAX,
     XP_MIN,
@@ -22,6 +26,9 @@ __all__ = [
     "TTLCache",
     "USER_CACHE_TTL",
     "UserXpStats",
+    "VOICE_TICK_SECONDS",
+    "VOICE_XP_PER_TICK_MAX",
+    "VOICE_XP_PER_TICK_MIN",
     "XP_COOLDOWN_SECONDS",
     "XP_MAX",
     "XP_MIN",
@@ -29,4 +36,5 @@ __all__ = [
     "calculate_level",
     "create_progress_bar",
     "get_rank_display",
+    "render_rank_card",
 ]

--- a/features/xp/card.py
+++ b/features/xp/card.py
@@ -1,0 +1,160 @@
+"""Image rank card renderer for the /rank command."""
+
+from __future__ import annotations
+
+from io import BytesIO
+from pathlib import Path
+
+from PIL import Image, ImageDraw, ImageFilter, ImageFont
+
+_FONT_PATH = str(Path(__file__).resolve().parent.parent.parent / "src" / "assets" / "OpenSans.ttf")
+
+CARD_WIDTH = 900
+CARD_HEIGHT = 280
+AVATAR_SIZE = 180
+PADDING = 30
+
+_BG = (24, 25, 28)
+_PANEL = (35, 37, 41)
+_BAR_BG = (50, 52, 58)
+_BAR_FG = (88, 196, 132)
+_TEXT_PRIMARY = (242, 243, 245)
+_TEXT_DIM = (170, 175, 185)
+_ACCENT = (88, 196, 132)
+
+
+def _circular_avatar(avatar_bytes: bytes, size: int) -> Image.Image:
+    img = Image.open(BytesIO(avatar_bytes)).convert("RGBA").resize((size, size))
+    mask = Image.new("L", (size, size), 0)
+    ImageDraw.Draw(mask).ellipse((0, 0, size, size), fill=255)
+    out = Image.new("RGBA", (size, size), (0, 0, 0, 0))
+    out.paste(img, (0, 0), mask=mask)
+    return out
+
+
+def _rounded_rect(
+    draw: ImageDraw.ImageDraw,
+    xy: tuple[int, int, int, int],
+    radius: int,
+    fill,
+) -> None:
+    draw.rounded_rectangle(xy, radius=radius, fill=fill)
+
+
+def render_rank_card(
+    *,
+    avatar_bytes: bytes | None,
+    username: str,
+    display_name: str,
+    level: int,
+    xp_in_level: int,
+    xp_to_next: int,
+    total_xp: int,
+    rank: int | None,
+    member_count: int | None,
+    message_count: int,
+) -> BytesIO:
+    """Render a 900×280 rank card. Returns a PNG ``BytesIO`` ready to upload."""
+    card = Image.new("RGB", (CARD_WIDTH, CARD_HEIGHT), _BG)
+    draw = ImageDraw.Draw(card)
+
+    # Inner panel for content.
+    _rounded_rect(
+        draw,
+        (PADDING // 2, PADDING // 2, CARD_WIDTH - PADDING // 2, CARD_HEIGHT - PADDING // 2),
+        radius=22,
+        fill=_PANEL,
+    )
+
+    # Avatar with subtle accent glow.
+    avatar_x, avatar_y = PADDING, (CARD_HEIGHT - AVATAR_SIZE) // 2
+    glow_size = AVATAR_SIZE + 24
+    glow = Image.new("RGBA", (glow_size, glow_size), (0, 0, 0, 0))
+    ImageDraw.Draw(glow).ellipse((0, 0, glow_size, glow_size), fill=(*_ACCENT, 110))
+    glow = glow.filter(ImageFilter.GaussianBlur(12))
+    card.paste(
+        glow,
+        (avatar_x - 12, avatar_y - 12),
+        glow,
+    )
+    if avatar_bytes:
+        try:
+            avatar = _circular_avatar(avatar_bytes, AVATAR_SIZE)
+            card.paste(avatar, (avatar_x, avatar_y), avatar)
+        except Exception:
+            draw.ellipse(
+                (avatar_x, avatar_y, avatar_x + AVATAR_SIZE, avatar_y + AVATAR_SIZE),
+                fill=_ACCENT,
+            )
+    else:
+        draw.ellipse(
+            (avatar_x, avatar_y, avatar_x + AVATAR_SIZE, avatar_y + AVATAR_SIZE),
+            fill=_ACCENT,
+        )
+
+    text_x = avatar_x + AVATAR_SIZE + PADDING
+    name_font = ImageFont.truetype(_FONT_PATH, 36)
+    sub_font = ImageFont.truetype(_FONT_PATH, 20)
+    big_font = ImageFont.truetype(_FONT_PATH, 30)
+    small_font = ImageFont.truetype(_FONT_PATH, 18)
+
+    # Top row: display name + (username) + rank chip.
+    name_truncated = display_name if len(display_name) <= 18 else display_name[:17] + "…"
+    draw.text((text_x, 40), name_truncated, font=name_font, fill=_TEXT_PRIMARY)
+    if username and username != display_name:
+        username_text = f"@{username}"
+        if len(username_text) > 20:
+            username_text = username_text[:19] + "…"
+        draw.text((text_x, 86), username_text, font=sub_font, fill=_TEXT_DIM)
+
+    rank_text = (
+        f"#{rank}"
+        + (f" / {member_count}" if member_count else "")
+        if rank
+        else "—"
+    )
+    rank_font = ImageFont.truetype(_FONT_PATH, 26)
+    rank_bbox = draw.textbbox((0, 0), rank_text, font=rank_font)
+    rank_w = rank_bbox[2] - rank_bbox[0]
+    chip_w = rank_w + 28
+    chip_h = 38
+    chip_x = CARD_WIDTH - PADDING - chip_w
+    chip_y = PADDING + 6
+    _rounded_rect(draw, (chip_x, chip_y, chip_x + chip_w, chip_y + chip_h), 18, _ACCENT)
+    draw.text(
+        (chip_x + 14, chip_y + 6),
+        rank_text,
+        font=rank_font,
+        fill=(20, 22, 25),
+    )
+
+    # Stats line.
+    stats_text = f"Niveau {level} · {message_count} message(s) · XP total : {total_xp}"
+    draw.text((text_x, 122), stats_text, font=big_font, fill=_TEXT_PRIMARY)
+
+    # Progress bar.
+    bar_x = text_x
+    bar_y = 180
+    bar_w = CARD_WIDTH - bar_x - PADDING
+    bar_h = 26
+    _rounded_rect(draw, (bar_x, bar_y, bar_x + bar_w, bar_y + bar_h), bar_h // 2, _BAR_BG)
+    if xp_to_next > 0:
+        ratio = max(0.0, min(1.0, xp_in_level / xp_to_next))
+        if ratio > 0:
+            filled_w = max(int(bar_w * ratio), bar_h)
+            _rounded_rect(
+                draw,
+                (bar_x, bar_y, bar_x + filled_w, bar_y + bar_h),
+                bar_h // 2,
+                _BAR_FG,
+            )
+    progress_text = f"{xp_in_level} / {xp_to_next} XP"
+    draw.text((bar_x, bar_y + bar_h + 6), progress_text, font=small_font, fill=_TEXT_DIM)
+
+    buffer = BytesIO()
+    card.save(buffer, format="PNG")
+    buffer.seek(0)
+    return buffer
+
+
+__all__ = ["render_rank_card"]

--- a/features/xp/card.py
+++ b/features/xp/card.py
@@ -107,12 +107,7 @@ def render_rank_card(
             username_text = username_text[:19] + "…"
         draw.text((text_x, 86), username_text, font=sub_font, fill=_TEXT_DIM)
 
-    rank_text = (
-        f"#{rank}"
-        + (f" / {member_count}" if member_count else "")
-        if rank
-        else "—"
-    )
+    rank_text = f"#{rank}" + (f" / {member_count}" if member_count else "") if rank else "—"
     rank_font = ImageFont.truetype(_FONT_PATH, 26)
     rank_bbox = draw.textbbox((0, 0), rank_text, font=rank_font)
     rank_w = rank_bbox[2] - rank_bbox[0]

--- a/features/xp/constants.py
+++ b/features/xp/constants.py
@@ -4,6 +4,13 @@ XP_COOLDOWN_SECONDS = 60
 XP_MIN = 15
 XP_MAX = 25
 
+# Voice XP: awarded on a per-minute tick while the user is in a non-AFK voice
+# channel with at least one other non-bot member. Same magnitude as messages,
+# scaled lower since voice presence is passive.
+VOICE_XP_PER_TICK_MIN = 5
+VOICE_XP_PER_TICK_MAX = 10
+VOICE_TICK_SECONDS = 60
+
 LEADERBOARD_PAGE_SIZE = 10
 RANK_MEDALS: list[str] = ["🥇", "🥈", "🥉"]
 
@@ -18,6 +25,9 @@ __all__ = [
     "RANK_CACHE_TTL",
     "RANK_MEDALS",
     "USER_CACHE_TTL",
+    "VOICE_TICK_SECONDS",
+    "VOICE_XP_PER_TICK_MAX",
+    "VOICE_XP_PER_TICK_MIN",
     "XP_COOLDOWN_SECONDS",
     "XP_MAX",
     "XP_MIN",

--- a/src/webui/schemas.py
+++ b/src/webui/schemas.py
@@ -19,7 +19,8 @@ import the DSL without triggering a circular import.
 Recognised widget types (``type=`` on ``ui()``):
     string, number, boolean, channel, role, message, secret, url,
     list, list:number, dict, messagelist, embedlist, keyvaluemap,
-    spotifymap, streamermap, teams, discord2name, models.
+    spotifymap, streamermap, youtubechannelmap, teams, discord2name,
+    models.
 """
 
 from typing import Any, ClassVar

--- a/src/webui/static/index.html
+++ b/src/webui/static/index.html
@@ -1637,6 +1637,75 @@
             }
         }
 
+        /* ── YouTube Channel Map Editor ──────────────── */
+        .youtubechannel-list {
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+        }
+
+        .youtubechannel-entry {
+            display: grid;
+            grid-template-columns: 1.4fr 1.4fr repeat(3, auto) auto;
+            gap: 10px;
+            align-items: center;
+            padding: 10px 12px;
+            background: var(--bg-primary);
+            border: 1px solid var(--border);
+            border-radius: var(--radius);
+        }
+
+        .youtubechannel-entry input[type="text"] {
+            padding: 6px 8px;
+            background: var(--bg-secondary);
+            border: 1px solid var(--border);
+            border-radius: var(--radius);
+            color: var(--text-primary);
+            font-size: 14px;
+            outline: none;
+        }
+
+        .youtubechannel-entry input[type="text"]:focus {
+            border-color: var(--accent);
+        }
+
+        .youtubechannel-toggle {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            font-size: 13px;
+            color: var(--text-secondary);
+            cursor: pointer;
+            white-space: nowrap;
+        }
+
+        .youtubechannel-toggle input[type="checkbox"] {
+            width: 15px;
+            height: 15px;
+            accent-color: var(--accent);
+            cursor: pointer;
+        }
+
+        .youtubechannel-entry .btn-remove-entry {
+            padding: 6px 10px;
+            background: transparent;
+            border: 1px solid var(--border);
+            border-radius: var(--radius);
+            color: var(--text-muted);
+            cursor: pointer;
+        }
+
+        .youtubechannel-entry .btn-remove-entry:hover {
+            color: var(--error);
+            border-color: var(--error);
+        }
+
+        @media (max-width: 720px) {
+            .youtubechannel-entry {
+                grid-template-columns: 1fr 1fr;
+            }
+        }
+
         /* ── Name Mapping List Editor ────────────────── */
         .namemap-list {
             display: flex;
@@ -2960,6 +3029,29 @@
                     break;
                 }
 
+                case 'youtubechannelmap': {
+                    let channelMap;
+                    if (Array.isArray(value)) {
+                        // Legacy list[str] config — migrate in-place to the
+                        // structured shape with VOD-only defaults.
+                        channelMap = {};
+                        for (const handle of value) {
+                            if (handle) channelMap[handle] = { shorts: false, live: false, vod: true };
+                        }
+                    } else if (typeof value === 'object' && value !== null) {
+                        channelMap = value;
+                    } else {
+                        channelMap = {};
+                    }
+                    html += `<div class="youtubechannel-list" data-field="${key}" data-type="youtubechannelmap">`;
+                    Object.entries(channelMap).forEach(([handle, cfg]) => {
+                        html += renderYoutubeChannelEntry(handle, cfg || {});
+                    });
+                    html += `</div>`;
+                    html += `<button type="button" class="btn-add-entry" onclick="addYoutubeChannelEntry(this)">+ Ajouter une chaîne</button>`;
+                    break;
+                }
+
                 case 'spotifymap':
                     const spotifyUsers = Array.isArray(value) ? value : [];
                     html += `<div class="spotifymap-list" data-field="${key}" data-type="spotifymap">`;
@@ -3125,6 +3217,9 @@
                 case 'streamermap':
                     // Handled separately below
                     continue;
+                case 'youtubechannelmap':
+                    // Handled separately below
+                    continue;
                 case 'messagelist':
                     // Handled separately below
                     continue;
@@ -3255,6 +3350,26 @@
             if (spotifyUsers.length > 0) {
                 result[key] = spotifyUsers;
             }
+        }
+
+        // Collect youtubechannelmap lists
+        const ytChannelLists = form.querySelectorAll('[data-type="youtubechannelmap"]');
+        for (const list of ytChannelLists) {
+            const key = list.dataset.field;
+            const entries = list.querySelectorAll('.youtubechannel-entry');
+            const channelMap = {};
+            for (const entry of entries) {
+                const handle = entry.querySelector('[data-yt-field="handle"]')?.value?.trim();
+                if (!handle) continue;
+                const label = entry.querySelector('[data-yt-field="label"]')?.value?.trim() || '';
+                const shorts = !!entry.querySelector('[data-yt-field="shorts"]')?.checked;
+                const live = !!entry.querySelector('[data-yt-field="live"]')?.checked;
+                const vod = !!entry.querySelector('[data-yt-field="vod"]')?.checked;
+                const cfg = { shorts, live, vod };
+                if (label) cfg.label = label;
+                channelMap[handle] = cfg;
+            }
+            result[key] = channelMap;
         }
 
         // Collect streamermap (Twitch) lists
@@ -3515,6 +3630,40 @@
         const entry = wrapper.firstElementChild;
         list.appendChild(entry);
         populateChannelPickers(entry);
+        entry.querySelector('input[type="text"]').focus();
+    }
+
+    function renderYoutubeChannelEntry(handle, cfg) {
+        const shorts = !!cfg.shorts;
+        const live = !!cfg.live;
+        const vod = cfg.vod !== false; // default true
+        return `
+            <div class="youtubechannel-entry">
+                <input type="text" data-yt-field="handle" value="${escapeHtml(handle || '')}" placeholder="@handle">
+                <input type="text" data-yt-field="label" value="${escapeHtml(cfg.label || '')}" placeholder="Libellé (optionnel)">
+                <label class="youtubechannel-toggle">
+                    <input type="checkbox" data-yt-field="shorts" ${shorts ? 'checked' : ''}>
+                    <span>Shorts</span>
+                </label>
+                <label class="youtubechannel-toggle">
+                    <input type="checkbox" data-yt-field="live" ${live ? 'checked' : ''}>
+                    <span>Live</span>
+                </label>
+                <label class="youtubechannel-toggle">
+                    <input type="checkbox" data-yt-field="vod" ${vod ? 'checked' : ''}>
+                    <span>VOD</span>
+                </label>
+                <button class="btn-remove-entry" onclick="this.closest('.youtubechannel-entry').remove()" title="Supprimer">✕</button>
+            </div>`;
+    }
+
+    function addYoutubeChannelEntry(btn) {
+        const list = btn.previousElementSibling;
+        if (!list || !list.classList.contains('youtubechannel-list')) return;
+        const wrapper = document.createElement('div');
+        wrapper.innerHTML = renderYoutubeChannelEntry('', { shorts: false, live: false, vod: true }).trim();
+        const entry = wrapper.firstElementChild;
+        list.appendChild(entry);
         entry.querySelector('input[type="text"]').focus();
     }
 
@@ -4629,6 +4778,30 @@
                                     <span style="color:var(--text-secondary);font-family:Consolas,monospace;">${escapeHtml(u.discordId || '')}</span>
                                 </div>
                             `).join('')}
+                        </div>
+                    </div>
+                `;
+                continue;
+            }
+
+            if (fieldType === 'youtubechannelmap' && typeof val === 'object' && val !== null && !Array.isArray(val)) {
+                const channels = Object.entries(val);
+                html += `
+                    <div class="preview-row" style="flex-direction:column;gap:6px;">
+                        <span class="preview-label">${field.label || key} (${channels.length})</span>
+                        <div style="display:flex;flex-direction:column;gap:4px;width:100%;">
+                            ${channels.length > 0 ? channels.map(([handle, cfg]) => {
+                                const flags = [];
+                                if (cfg?.shorts) flags.push('Shorts');
+                                if (cfg?.live) flags.push('Live');
+                                if (cfg?.vod !== false) flags.push('VOD');
+                                const label = cfg?.label ? ` (${escapeHtml(String(cfg.label))})` : '';
+                                return `
+                                <div style="display:flex;gap:8px;align-items:center;padding:4px 8px;background:var(--bg-primary);border-radius:var(--radius);font-size:13px;">
+                                    <span style="font-weight:600;color:var(--accent);min-width:140px;">${escapeHtml(handle)}${label}</span>
+                                    <span style="color:var(--text-muted);font-family:Consolas,monospace;flex:1;">${flags.join(' · ') || '—'}</span>
+                                </div>`;
+                            }).join('') : '<span style="color:var(--text-muted);font-size:13px;">Aucune chaîne configurée</span>'}
                         </div>
                     </div>
                 `;


### PR DESCRIPTION
## Summary

Round of extension improvements across eight modules.

### admin
- New `/slowmode`, `/lock`, `/unlock` commands (Manage Channels permission)

### polls
- `/poll` gains an optional `duree=` (e.g. `30m`, `2h`, `1d`) that auto-closes the reaction poll, locks the title and clears reactions
- New `/poll-anonyme` — button-based voting; counts public, voters hidden
- New `/poll-classement` — instant-runoff (ranked-choice) with per-round tally and a "Réinitialiser mon classement" button
- Button polls are persisted (per-guild MongoDB `polls` collection) and closed by a 30 s sweep task

### reminders
- `/reminder set` accepts a `destinataires=` field (mentions or IDs, comma/space separated) for shared/group reminders; everyone listed is DM'd
- Each DM ships with a "Snooze 10 min" button that re-fires the reminder for the clicker

### twitch
- Resolves the long-standing TODO: scheduled events are now matched to streamers by their `external_location` URL (`https://twitch.tv/{handle}`), so multi-streamer guilds no longer cross-assign events. Falls back to legacy single-streamer claim only when the guild tracks one streamer.

### tricount
- `/depense` accepts a `categorie=` with autocomplete (defaults + previously used custom categories)
- New `/depense-recurrente {ajouter|lister|arreter}` with daily/weekly/monthly/yearly cadences; a 5 min task materialises due occurrences
- New `/tricount-graphique` exports a Pillow-rendered breakdown by category

### xp
- Voice XP: per-minute tick (`VoiceMixin`) awards 5–10 XP while the member is in a non-AFK channel with at least one other non-bot member
- Level-up role rewards: per-guild `levelRewards` map (`{level: roleId}`) with optional `stackLevelRewards` to keep or replace lower-tier roles
- Image rank cards: `/rank` now responds with a Pillow-rendered card (avatar, name, level, XP bar, rank chip), with embed fallback if rendering fails

### youtube
- New per-guild toggles: `youtubeIncludeShorts`, `youtubeIncludeLive`, `youtubeIncludeVod` (default mirrors previous VOD-only behaviour)
- `is_video_valid` consumes the per-guild filter dict
- `@handle` and bare handles both resolve in the channel list

### welcome
- New Pillow-rendered welcome/leave card (avatar + username + server subtitle); `welcomeImageEnabled` toggle in the dashboard schema

## Test plan
- [ ] `/slowmode 30`, `/lock`, `/unlock` on a test channel
- [ ] `/poll question:Test? options:A;B;C duree:5m` then verify auto-close at the deadline
- [ ] `/poll-anonyme` and `/poll-classement`: confirm button voting, counts, and (for ranked) reset behaviour
- [ ] `/reminder set` with `destinataires=` of two users; click snooze on the DM
- [ ] Twitch: with two streamers tracked in one guild, restart the bot and confirm each StreamerInfo binds to its own scheduled event
- [ ] `/depense` with a category, `/depense-recurrente ajouter`, wait for the 5-min tick, then `/tricount-graphique`
- [ ] `/rank` returns the rendered image; configure a `levelRewards` entry and verify the role is granted on level-up; join a voice channel with another member and confirm XP increments
- [ ] YouTube: flip `youtubeIncludeShorts` true on a test guild and confirm a Short fires a notification

https://claude.ai/code/session_01GDi6ZYNBWmh3pr2CaEyY5M

---
_Generated by [Claude Code](https://claude.ai/code/session_01GDi6ZYNBWmh3pr2CaEyY5M)_