### PR TITLE
docs(claude): document Web UI extension points (schemas + custom views)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,10 @@ When an extension grows past ~200 lines, promote it to a package and split respo
 
 Any extension that reads from `config["module<Name>"]` should declare a Pydantic schema using the `@register_module(...)` decorator from `src.webui.schemas` (typically in `extensions/<name>/_common.py`, see `extensions/xp/_common.py` for a canonical example). This is what makes the module appear in the dashboard with editable, typed fields, per-server toggles, and validation — without it the only way to configure the extension is hand-editing `config/config.json` and restarting. New global config sections use `@register_section(...)` the same way.
 
+### Custom Web UI views
+
+When schema-driven forms aren't enough (e.g. CRUD over a list of objects, anything that mutates Discord state from the dashboard), drop a router in `src/webui/routes/<name>.py` exposing a `create_router(ctx: WebUIContext) -> APIRouter` factory and register it in `src/webui/app.py` next to the others. `ctx` carries the bot client, the config store, and the auth helpers, so routes can both read MongoDB *and* call back into Discord (post/edit messages, etc.). The reaction-role menu builder (`src/webui/routes/rolemenus.py` paired with `features/reactionroles/`) is the reference pattern. The frontend lives in a single SPA at `src/webui/static/index.html`; `frontend.py` catch-alls any unknown path back to it, so new views are added by extending that file rather than creating per-view templates.
+
 ### Per-guild data isolation
 
 Each Discord server gets its own MongoDB database named `guild_{guild_id}`; cross-guild data lives in a shared `global` database. Access via the singleton in `src/core/db.py`. Repositories under `features/<name>/repository.py` encapsulate this.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,10 @@ Three-layer split. Respect the boundaries:
 
 When an extension grows past ~200 lines, promote it to a package and split responsibilities into mixin modules (e.g. `xp/leveling.py`, `xp/commands.py`, `xp/leaderboard.py`) composed via multiple inheritance in `__init__.py`. Shared constants and the Pydantic config schema go in `_common.py`. Domain logic moves into a matching `features/<name>/` package.
 
+### Web UI schema (strongly recommended for any new extension)
+
+Any extension that reads from `config["module<Name>"]` should declare a Pydantic schema using the `@register_module(...)` decorator from `src.webui.schemas` (typically in `extensions/<name>/_common.py`, see `extensions/xp/_common.py` for a canonical example). This is what makes the module appear in the dashboard with editable, typed fields, per-server toggles, and validation — without it the only way to configure the extension is hand-editing `config/config.json` and restarting. New global config sections use `@register_section(...)` the same way.
+
 ### Per-guild data isolation
 
 Each Discord server gets its own MongoDB database named `guild_{guild_id}`; cross-guild data lives in a shared `global` database. Access via the singleton in `src/core/db.py`. Repositories under `features/<name>/repository.py` encapsulate this.


### PR DESCRIPTION
## Summary
- Adds two short sections to `CLAUDE.md` covering the Web UI extension points so future contributors don't ship "invisible" extensions or reinvent the dashboard plumbing.
- **Web UI schema** — declare a `@register_module(...)` Pydantic schema (typically in `extensions/<name>/_common.py`, see `extensions/xp/_common.py`) so the module appears in the dashboard with typed fields, per-server toggles, and validation. `@register_section(...)` is the same pattern for global config.
- **Custom Web UI views** — for things that need more than a form (CRUD lists, mutations that hit Discord), drop a `create_router(ctx)` factory in `src/webui/routes/<name>.py`, register it in `src/webui/app.py`, and extend the SPA at `src/webui/static/index.html`. The reaction-role menu builder (`routes/rolemenus.py` + `features/reactionroles/`) is the reference pattern.

## Test plan
- [ ] Markdown renders cleanly on GitHub.
- [ ] No code paths touched, so CI lint/typecheck/test should pass unchanged.

https://claude.ai/code/session_0152Bq2AnVLUo1r67KiPWi21