### PR TITLE
fix(rss,giveaway): inline module key in load_config so WebUI auto-reload works

### DIFF
--- a/extensions/giveaway/_common.py
+++ b/extensions/giveaway/_common.py
@@ -28,7 +28,10 @@ class GiveawayConfig(SchemaBase):
     )
 
 
-_, module_config, enabled_servers = load_config(MODULE_KEY)
+# NOTE: keep the literal string here — the WebUI's ``build_module_to_extension_map``
+# scans source files with a regex matching ``load_config("…")``, so a constant
+# would make the module invisible to the dashboard's auto-reload.
+_, module_config, enabled_servers = load_config("moduleGiveaway")
 enabled_servers_int = [int(s) for s in enabled_servers]
 
 

--- a/extensions/rss/_common.py
+++ b/extensions/rss/_common.py
@@ -54,7 +54,10 @@ class RssConfig(SchemaBase):
     )
 
 
-_, module_config, enabled_servers = load_config(MODULE_KEY)
+# NOTE: keep the literal string here — the WebUI's ``build_module_to_extension_map``
+# scans source files with a regex matching ``load_config("…")``, so a constant
+# would make the module invisible to the dashboard's auto-reload.
+_, module_config, enabled_servers = load_config("moduleRss")
 enabled_servers_int = [int(s) for s in enabled_servers]
 
 


### PR DESCRIPTION
## Summary

Fixes the dashboard error reported on save:
> Configuration sauvegardée, rechargement échoué : Aucune extension trouvée pour moduleRss

`src/webui/context.py:142` builds the module-name → extension-path map by walking each `extensions/**/*.py` and matching `load_config("…")` with a literal-string regex (`r'load_config\(["\']([\w]+)["\']\)'`). Both new extensions had been calling `load_config(MODULE_KEY)` with a constant — the regex doesn't follow the indirection, so neither `moduleRss` nor `moduleGiveaway` ended up in the map and the post-save reload bailed.

Inline the literal in both `_common.py` files. Added an explanatory comment so the next contributor doesn't refactor it back to a constant.

Verified locally:

```
moduleRss: extensions.rss
moduleGiveaway: extensions.giveaway
```

## Test plan

- [x] `ruff check .` — clean
- [x] `pytest tests/` — 19/19 pass
- [x] Re-ran the regex offline against both files; both resolve correctly
- [ ] In production: save the RSS module config and confirm the reload toast no longer fails

https://claude.ai/code/session_01ELoUJYkiqdC4dfs9KuUJk1

---
_Generated by [Claude Code](https://claude.ai/code/session_01ELoUJYkiqdC4dfs9KuUJk1)_