### PR TITLE
fix(welcome,xp): use Asset.fetch() so the avatar actually loads

### DIFF
--- a/extensions/welcome.py
+++ b/extensions/welcome.py
@@ -2,7 +2,6 @@
 
 import os
 
-import httpx
 from interactions import Client, Extension, File, listen
 from interactions.api.events import MemberAdd, MemberRemove
 
@@ -58,24 +57,20 @@ config, module_config, enabled_servers = load_config("moduleWelcome")
 
 
 async def _fetch_avatar_bytes(member) -> bytes | None:
-    """Best-effort download of the member's avatar PNG."""
-    avatar_url = getattr(member, "display_avatar", None) or getattr(member, "avatar_url", None)
-    if avatar_url is None:
+    """Best-effort download of the member's avatar as PNG bytes.
+
+    interactions.py exposes ``display_avatar`` as an :class:`Asset` whose
+    ``fetch()`` method talks to Discord's CDN through the bot's authenticated
+    HTTP client — the recommended path. We force the PNG extension so animated
+    avatars decode to a still frame.
+    """
+    asset = getattr(member, "display_avatar", None) or getattr(member, "avatar", None)
+    if asset is None:
         return None
-    url = str(avatar_url)
-    if "?" in url:
-        url = url.split("?", 1)[0]
-    if "." in url.rsplit("/", 1)[-1]:
-        # Force PNG so animated avatars decode to a still frame.
-        url = url.rsplit(".", 1)[0] + ".png"
-    url = f"{url}?size=256"
     try:
-        async with httpx.AsyncClient(timeout=8.0) as client:
-            response = await client.get(url)
-            response.raise_for_status()
-            return response.content
+        return await asset.fetch(extension=".png", size=256)
     except Exception as e:
-        logger.debug("Could not fetch avatar for %s: %s", getattr(member, "id", "?"), e)
+        logger.warning("Could not fetch avatar for %s: %s", getattr(member, "id", "?"), e)
         return None
 
 

--- a/extensions/xp/commands.py
+++ b/extensions/xp/commands.py
@@ -2,7 +2,6 @@
 
 from datetime import datetime
 
-import httpx
 import pymongo
 from interactions import (
     Client,
@@ -29,24 +28,19 @@ from ._common import EMBED_COLOR, TIMEZONE, enabled_servers, logger
 
 
 async def _fetch_avatar_bytes(target_user) -> bytes | None:
-    avatar_url = getattr(target_user, "display_avatar", None) or getattr(
-        target_user, "avatar_url", None
-    )
-    if avatar_url is None:
+    """Pull the user's avatar through interactions.py's Asset.fetch helper.
+
+    ``str(asset)`` returns the attrs repr, not the CDN URL — using
+    ``Asset.fetch()`` is the supported way and goes through the bot's HTTP
+    client, which knows how to handle CDN responses.
+    """
+    asset = getattr(target_user, "display_avatar", None) or getattr(target_user, "avatar", None)
+    if asset is None:
         return None
-    url = str(avatar_url)
-    if "?" in url:
-        url = url.split("?", 1)[0]
-    if "." in url.rsplit("/", 1)[-1]:
-        url = url.rsplit(".", 1)[0] + ".png"
-    url = f"{url}?size=256"
     try:
-        async with httpx.AsyncClient(timeout=8.0) as client:
-            response = await client.get(url)
-            response.raise_for_status()
-            return response.content
+        return await asset.fetch(extension=".png", size=256)
     except Exception as e:
-        logger.debug("Could not fetch avatar for rank card: %s", e)
+        logger.warning("Could not fetch avatar for rank card: %s", e)
         return None
 
 


### PR DESCRIPTION
## Summary

The avatar circle on the welcome / leave card and the `/rank` card were always falling back to the blue placeholder. Root cause: `_fetch_avatar_bytes` did `str(member.display_avatar)` and treated the result as a CDN URL, but interactions.py's `Asset` is an `attrs.define`d class with no `__str__`, so `str(asset)` returned the attrs repr (`Asset(_url='https://cdn.discordapp.com/avatars/...', hash='...')`). httpx then GET'd that garbage string, the exception was logged at `debug` level (invisible), and the renderer used the placeholder.

Fix: use the supported `await asset.fetch(extension='.png', size=256)` API, which talks to the CDN through the bot's HTTP client, and bump the log level to `warning` so future failures are visible. Same fix in `extensions/xp/commands.py`. The `httpx` dependency in both modules is no longer needed.

## Test plan
- [ ] Trigger a welcome / leave event → the card embeds the actual avatar instead of the blue placeholder
- [ ] `/rank` returns the rank card with the real avatar
- [ ] If the user has an animated (`a_…`) avatar, the card shows the still PNG frame
- [ ] If `display_avatar` is absent, the renderer falls back to the placeholder gracefully (no crash)

https://claude.ai/code/session_01GDi6ZYNBWmh3pr2CaEyY5M

---
_Generated by [Claude Code](https://claude.ai/code/session_01GDi6ZYNBWmh3pr2CaEyY5M)_