### PR TITLE
Add Web UI schemas for birthday, feur, secretsanta and uptime

### DIFF
--- a/extensions/birthday.py
+++ b/extensions/birthday.py
@@ -43,6 +43,42 @@ from src.core.text import pick_weighted_message
 from src.discord_ext.embeds import Colors
 from src.discord_ext.messages import fetch_user_safe, require_guild
 from src.discord_ext.paginator import CustomPaginator
+from src.webui.schemas import SchemaBase, enabled_field, register_module, ui
+
+
+@register_module("moduleBirthday")
+class BirthdayConfig(SchemaBase):
+    __label__ = "Anniversaires"
+    __description__ = "Vœux d'anniversaire quotidiens, rôle du jour et liste des anniversaires."
+    __icon__ = "🎂"
+    __category__ = "Communauté"
+
+    enabled: bool = enabled_field()
+    birthdayChannelId: str | None = ui(
+        "Salon des vœux",
+        "channel",
+        description="Salon où les vœux sont envoyés (salon système du serveur par défaut).",
+    )
+    birthdayRoleId: str | None = ui(
+        "Rôle anniversaire",
+        "role",
+        description="Rôle attribué au membre le jour de son anniversaire (optionnel).",
+    )
+    birthdayGuildLocale: str = ui(
+        "Locale des dates",
+        "string",
+        default="en_US",
+        description="Locale utilisée pour formater les dates de la liste (ex : fr_FR).",
+    )
+    birthdayMessageList: list[str] = ui(
+        "Messages d'anniversaire",
+        "messagelist",
+        description="Liste de messages avec poids de probabilité.",
+        default=["Joyeux anniversaire {mention} ! 🎉"],
+        weight_field="birthdayMessageWeights",
+        variables="{mention}, {age}",
+    )
+
 
 logger = logutil.init_logger(os.path.basename(__file__))
 config, module_config, enabled_servers = load_config("moduleBirthday")

--- a/extensions/feur.py
+++ b/extensions/feur.py
@@ -17,6 +17,18 @@ from src.core.config import load_config
 from src.core.text import sanitize_content
 from src.discord_ext.embeds import Colors
 from src.discord_ext.messages import require_guild
+from src.webui.schemas import SchemaBase, enabled_field, register_module
+
+
+@register_module("moduleFeur")
+class FeurConfig(SchemaBase):
+    __label__ = "Feur"
+    __description__ = 'Répond "feur" aux messages se terminant par "quoi", avec stats par membre.'
+    __icon__ = "🇫"
+    __category__ = "Communauté"
+
+    enabled: bool = enabled_field()
+
 
 logger = logutil.init_logger(os.path.basename(__file__))
 

--- a/extensions/secretsanta/_common.py
+++ b/extensions/secretsanta/_common.py
@@ -14,6 +14,21 @@ from interactions import (
 
 from src.core import logging as logutil
 from src.core.config import load_config
+from src.webui.schemas import SchemaBase, enabled_field, register_module
+
+
+@register_module("moduleSecretSanta")
+class SecretSantaConfig(SchemaBase):
+    __label__ = "Secret Santa"
+    __description__ = (
+        "Secret Santa dans Discord : inscriptions, exclusions, tirage et envoi des "
+        "assignations par MP. Réglages globaux dans la section « Secret Santa (global) »."
+    )
+    __icon__ = "🎁"
+    __category__ = "Événements"
+
+    enabled: bool = enabled_field()
+
 
 logger = logutil.init_logger(os.path.basename(__file__))
 config, module_config, enabled_servers = load_config("moduleSecretSanta")

--- a/extensions/uptime/_common.py
+++ b/extensions/uptime/_common.py
@@ -4,6 +4,21 @@ import os
 
 from src.core import logging as logutil
 from src.core.config import load_config
+from src.webui.schemas import SchemaBase, enabled_field, register_module
+
+
+@register_module("moduleUptime")
+class UptimeConfig(SchemaBase):
+    __label__ = "Uptime"
+    __description__ = (
+        "Suivi Uptime Kuma : statut des serveurs et notifications de maintenance. "
+        "Les capteurs se configurent via /uptime ; identifiants dans la section « Uptime Kuma »."
+    )
+    __icon__ = "📡"
+    __category__ = "Outils"
+
+    enabled: bool = enabled_field()
+
 
 logger = logutil.init_logger(os.path.basename(__file__))
 


### PR DESCRIPTION
Second batch from the codebase review: the four modules that read per-guild config but declared no `@register_module` schema, making them invisible in the dashboard. Until now the only way to enable them per server (or configure birthday) was hand-editing `config/config.json` and restarting the bot.

## What's added

| Module | Schema | Notes |
|--------|--------|-------|
| `moduleBirthday` | Full | Wish channel (falls back to system channel), birthday role, date-format locale, weighted message list with `{mention}`/`{age}` variables — mirrors every key `birthday.py` actually reads |
| `moduleFeur` | Enable toggle | The extension reads no other per-guild keys — gating is membership in `module_config` |
| `moduleSecretSanta` | Enable toggle | Per-guild config is enablement-only; file path and encryption key already live in the existing `SecretSanta` global section, which the description points to |
| `moduleUptime` | Enable toggle | Sensors are configured via `/uptime` commands (MongoDB-backed); Kuma credentials live in the existing `uptimeKuma` global section — description points to both |

Schemas follow the established conventions: inline at the top for single-file extensions (like `welcome.py`), in `_common.py` for packages (like `xp`), French labels, existing categories (Communauté / Événements / Outils).

## Note on the review finding

The original review flagged 5 modules; `backup` turned out to already be covered by `@register_section("backup")` in `src/webui/schemas.py`, so it's not part of this PR.

## Verification

- Imported all four modules in a venv and confirmed `MODULE_SCHEMAS` now contains the four keys with the expected fields and categories
- `ruff check`, `ruff format --check`, `mypy src`, and the test suite (42/42) all pass

https://claude.ai/code/session_013YC9RjMQVzzuyq3S3BzVYT

---
_Generated by [Claude Code](https://claude.ai/code/session_013YC9RjMQVzzuyq3S3BzVYT)_