### PR TITLE
fix(mdi): resolve tracked team per bracket ahead of season finals

### DIFF
--- a/extensions/mdi/api.py
+++ b/extensions/mdi/api.py
@@ -93,11 +93,13 @@ class ApiMixin:
         # Bracket order matches the natural API order; we approximate it via slug
         # ordering for stability when the API list is missing.
         slug_priority = {
+            "time-trials": 0,
             "group-a": 1,
             "group-b": 2,
             "group-c": 3,
-            "season-finals": 4,
-            "global-finals": 5,
+            "china-region-finals": 4,
+            "season-finals": 5,
+            "global-finals": 6,
         }
         priority = slug_priority.get(match.bracket_slug, 99)
         return (priority, match.bracket_slug, match.round, match.match_order)

--- a/extensions/mdi/embeds.py
+++ b/extensions/mdi/embeds.py
@@ -128,7 +128,12 @@ class EmbedsMixin:
 
         for slug, group_matches in groups.items():
             bracket_title = bracket_titles.get(slug, slug)
-            blocks: list[str] = [self._schedule_line(match, team) for match in group_matches]
+            # Team ids are per-bracket on Raider.IO — resolve the ref from each
+            # match so win/loss and opponent detection stay correct across brackets.
+            blocks: list[str] = [
+                self._schedule_line(match, match.team_by_slug(team_slug) or team)
+                for match in group_matches
+            ]
             value = "\n".join(blocks) if blocks else "—"
             # Discord limits each field value to 1024 characters; chunk if needed.
             for chunk_index, chunk in enumerate(self._chunk_field_value(value)):

--- a/extensions/mdi/notifications.py
+++ b/extensions/mdi/notifications.py
@@ -106,8 +106,10 @@ class NotificationsMixin:
     # ── Per-match handler ────────────────────────────────────────────────────
 
     async def _process_match(self, state: GuildState, match: MatchSnapshot) -> None:
-        team = state.tracked_team
         gc = state.guild_config
+        # Raider.IO team ids are per-bracket: prefer the ref carried by this
+        # match so the win/loss verdict is computed against the right id.
+        team = match.team_by_slug(gc.team_slug) or state.tracked_team
         channel = state.notification_channel
         if channel is None:
             return

--- a/features/mdi/client.py
+++ b/features/mdi/client.py
@@ -204,6 +204,21 @@ class MatchSnapshot:
             self.second_team is not None and self.second_team.slug.lower() == slug_lower
         )
 
+    def team_by_slug(self, slug: str) -> TeamRef | None:
+        """Return this match's :class:`TeamRef` for *slug*, if it plays here.
+
+        Raider.IO team ids are per-bracket registrations: the same roster gets a
+        different ``id`` (and seed) in each bracket it enters. Winner checks must
+        therefore use the ref carried by the match itself, never one resolved
+        from another bracket.
+        """
+        slug_lower = slug.lower()
+        if self.first_team is not None and self.first_team.slug.lower() == slug_lower:
+            return self.first_team
+        if self.second_team is not None and self.second_team.slug.lower() == slug_lower:
+            return self.second_team
+        return None
+
     def opponent_of(self, team_id: int) -> TeamRef | None:
         if self.first_team is not None and self.first_team.id == team_id:
             return self.second_team

--- a/tests/test_mdi_client.py
+++ b/tests/test_mdi_client.py
@@ -1,0 +1,99 @@
+"""Unit tests for ``features.mdi.client``.
+
+Payload shapes mirror https://raider.io/api/events/mdi-midnight-season-1/brackets
+(and ``…/brackets/<slug>``) as observed live in June 2026.
+"""
+
+from features.mdi.client import GameSnapshot, MatchSnapshot, TeamRef, _build_match
+
+
+def _team_payload(team_id: int, slug: str, name: str, seed: int) -> dict:
+    return {
+        "id": team_id,
+        "seed": seed,
+        "name": name,
+        "slug": slug,
+        "region": {"name": "Europe", "slug": "eu", "short_name": "EU"},
+        "icon_logo_url": "https://example.com/logo.png",
+        "teamEventProfileUrl": "/event-teams/mdi/" + slug,
+    }
+
+
+def _match_payload(team_id: int, winner: bool) -> dict:
+    return {
+        "id": 10783,
+        "round": 1,
+        "match": 1,
+        "position": "upper",
+        "status": "complete" if winner else "unstarted",
+        "winnerTeamId": team_id if winner else None,
+        "gracePeriodEndsAt": "2026-06-07T15:47:26Z",
+        "firstTeam": _team_payload(team_id, "mandatory", "Mandatory", 5),
+        "secondTeam": _team_payload(8000, "interrupt", "Interrupt!", 4),
+        "games": [
+            {
+                "id": 49726,
+                "gameOrder": 1,
+                "status": "complete" if winner else "unstarted",
+                "winnerTeamId": team_id if winner else None,
+                "details": {
+                    "mythicLevel": 15,
+                    "firstTeamDeaths": 0,
+                    "secondTeamDeaths": 7,
+                    "firstTeamSplit1": "5:16",
+                    "secondTeamSplit1": "6:09",
+                    "firstTeamSplit2": "4:43",
+                    "secondTeamSplit2": None,
+                },
+                "dungeon": {
+                    "name": "Pit of Saron",
+                    "short_name": "POS",
+                    "keystone_timer_ms": 1800999,
+                },
+                "videoId": None,
+                "videoType": None,
+            }
+        ],
+    }
+
+
+def test_build_match_parses_live_payload_shape() -> None:
+    match = _build_match(_match_payload(7798, winner=True), "season-finals", "Season Finals")
+    assert isinstance(match, MatchSnapshot)
+    assert match.id == 10783
+    assert match.status == "complete"
+    assert match.winner_team_id == 7798
+    # Matches no longer carry startsAt/scheduledAt — must degrade to None.
+    assert match.starts_at is None
+    assert match.first_team is not None and match.first_team.name == "Mandatory"
+    assert match.second_team is not None and match.second_team.slug == "interrupt"
+
+    game = match.games[0]
+    assert isinstance(game, GameSnapshot)
+    assert game.mythic_level == 15
+    assert game.dungeon_short_name == "POS"
+    assert game.first_team_splits == (316, 283)
+    # Second team's split2 is null: collection stops at the first missing split.
+    assert game.second_team_splits == (369,)
+    assert game.keystone_timer_seconds == 1800
+
+
+def test_team_by_slug_returns_per_bracket_ref() -> None:
+    # Raider.IO registers the same roster under a different team id per bracket
+    # (Mandatory was 7681 in group-a and 7798 in season-finals). Winner checks
+    # must use the id carried by the match itself.
+    group_a = _build_match(_match_payload(7681, winner=True), "group-a", "Group A")
+    finals = _build_match(_match_payload(7798, winner=True), "season-finals", "Season Finals")
+    assert group_a is not None and finals is not None
+
+    ref_a = group_a.team_by_slug("mandatory")
+    ref_f = finals.team_by_slug("MANDATORY")  # lookup is case-insensitive
+    assert isinstance(ref_a, TeamRef) and ref_a.id == 7681
+    assert isinstance(ref_f, TeamRef) and ref_f.id == 7798
+
+    # The stale cross-bracket id misclassifies the win; the per-match ref doesn't.
+    assert finals.winner_team_id != ref_a.id
+    assert finals.winner_team_id == ref_f.id
+    assert finals.games_won_by(ref_f.id) == 1
+    assert finals.opponent_of(ref_f.id) is not None
+    assert finals.team_by_slug("unknown-team") is None


### PR DESCRIPTION
## Context

The MDI tracker already targets the API the user pointed at — `https://raider.io/api/events/mdi-midnight-season-1/brackets[/<slug>]` — and the parser was verified end-to-end against the live payloads (7 brackets, 70 matches parsed). But validating against the **season-finals** bracket (starts June 12) surfaced a real bug that would have hit during the event.

## Bug

Raider.IO registers the same roster under a **different team id in each bracket**: Mandatory is id `7681` in `group-a` but `7798` in `season-finals`. The extension resolved the tracked team once (from the first bracket found, i.e. group-a) and compared `winner_team_id == team.id` everywhere. For season-finals matches this meant:

- opponent rendered as **"TBD"** instead of "Interrupt!" (`opponent_of(7681)` finds nothing),
- the score line stuck at **0 – n**,
- a Mandatory **win would have rendered as "DÉFAITE 😢"** (winner id `7798 != 7681` but non-null).

## Fix

- `features/mdi/client.py`: add `MatchSnapshot.team_by_slug()` returning the per-bracket `TeamRef`.
- `extensions/mdi/embeds.py` + `extensions/mdi/notifications.py`: resolve the team from each match (falling back to the globally resolved ref), so win/loss verdicts, opponent names, and scores use the right per-bracket id.
- `extensions/mdi/api.py`: add `time-trials` and `china-region-finals` to the bracket sort order (present in the live bracket list, previously sorted last).
- `tests/test_mdi_client.py`: backfill unit tests for the parser against the current payload shape (matches no longer carry `startsAt`/`scheduledAt` — display already degrades gracefully) and a regression test for the per-bracket id behaviour.

## Verification

- Ran `features.mdi.client` + `EmbedsMixin` end-to-end against the live API: group-a matches render 🏆 VICTOIRE with id 7681; the season-finals match resolves id 7798 and renders `🟡 vs **Interrupt!** — WB R1`.
- `pytest` (44 passed), `ruff check` / `ruff format --check` clean. CI's `mypy src` scope is untouched.

https://claude.ai/code/session_01XfDwJnfotuNURWzBxty7d5

---
_Generated by [Claude Code](https://claude.ai/code/session_01XfDwJnfotuNURWzBxty7d5)_