### PR TITLE
Fix dashboard 500 (motor event-loop binding) + reliability small fixes

### DIFF
--- a/extensions/zevent/__init__.py
+++ b/extensions/zevent/__init__.py
@@ -5,6 +5,7 @@ APIs, Twitch stream aggregation, embed rendering, the refresh task, and the
 ``/zevent_finish`` command.
 """
 
+import asyncio
 import os
 from datetime import timedelta
 
@@ -39,6 +40,7 @@ class Zevent(Extension, ApiMixin, StreamsMixin, EmbedsMixin, TasksMixin, Command
         self.message: Message | None = None
         self.twitch: Twitch | None = None
         self.last_milestone = 0
+        self._milestone_lock = asyncio.Lock()
         self.last_data_cache: dict | None = None
         self.last_update_time = None
         self._streamer_cache: dict[str, str] = {}

--- a/extensions/zevent/tasks.py
+++ b/extensions/zevent/tasks.py
@@ -204,22 +204,23 @@ class TasksMixin:
             await self.send_simplified_update(total_amount)
 
     async def check_and_send_milestone(self, total_amount: float):
-        current_milestone = int(total_amount // MILESTONE_INTERVAL * MILESTONE_INTERVAL)
+        # Serialize the read-modify-write on last_milestone so overlapping
+        # task runs can't both pass the comparison and announce twice.
+        async with self._milestone_lock:
+            current_milestone = int(total_amount // MILESTONE_INTERVAL * MILESTONE_INTERVAL)
 
-        if current_milestone > self.last_milestone:
-            if self.last_milestone != 0:
-                milestone_message = (
-                    f"🎉 Nouveau palier atteint : {current_milestone:,} € récoltés ! 🎉".replace(
+            if current_milestone > self.last_milestone:
+                if self.last_milestone != 0:
+                    milestone_message = f"🎉 Nouveau palier atteint : {current_milestone:,} € récoltés ! 🎉".replace(
                         ",", " "
                     )
-                )
-                if self.channel and hasattr(self.channel, "send"):
-                    await self.channel.send(milestone_message)
-                else:
-                    logger.error(
-                        "Cannot send milestone message: channel not available or doesn't support sending"
-                    )
-            self.last_milestone = current_milestone
+                    if self.channel and hasattr(self.channel, "send"):
+                        await self.channel.send(milestone_message)
+                    else:
+                        logger.error(
+                            "Cannot send milestone message: channel not available or doesn't support sending"
+                        )
+                self.last_milestone = current_milestone
 
     async def send_simplified_update(self, total_amount: str):
         """Fallback embed used when API fetch and cache both fail."""

--- a/extensions/zunivers/_common.py
+++ b/extensions/zunivers/_common.py
@@ -20,6 +20,11 @@ class ZuniversConfig(SchemaBase):
     colocZuniversChannelId: str | None = ui(
         "Salon Zunivers", "channel", description="Salon pour les notifications Zunivers."
     )
+    journaReminderRoleId: str | None = ui(
+        "Rôle rappel /journa",
+        "role",
+        description="Rôle mentionné quand le /journa quotidien n'a pas été posté à 22h.",
+    )
 
 
 logger = logutil.init_logger("extensions.zunivers")

--- a/extensions/zunivers/corporation.py
+++ b/extensions/zunivers/corporation.py
@@ -23,7 +23,7 @@ from features.coloc.utils import (
     create_corporation_logs_embed,
 )
 
-from ._common import logger
+from ._common import enabled_servers, logger
 
 
 class CorporationMixin:
@@ -64,7 +64,7 @@ class CorporationMixin:
     @slash_command(
         name="corpo",
         description="Affiche les informations de la corporation",
-        scopes=[668445729928249344],
+        scopes=enabled_servers,
     )
     @slash_option(
         name="date",

--- a/extensions/zunivers/reminders.py
+++ b/extensions/zunivers/reminders.py
@@ -29,7 +29,7 @@ from features.coloc.constants import (
 )
 from src.discord_ext.messages import fetch_user_safe
 
-from ._common import enabled_servers, logger
+from ._common import enabled_servers, logger, module_config
 
 
 class RemindersMixin:
@@ -56,9 +56,9 @@ class RemindersMixin:
             logger.info("Daily journa already posted, skipping reminder")
             return
 
-        await channel.send(
-            ":robot: <@&934560421912911882>, heureusement que les robots n'oublient pas ! :robot:"
-        )
+        role_id = module_config.get("journaReminderRoleId")
+        mention = f"<@&{role_id}>, " if role_id else ""
+        await channel.send(f":robot: {mention}heureusement que les robots n'oublient pas ! :robot:")
 
     # ==================== Reminder Management ====================
 

--- a/src/core/db.py
+++ b/src/core/db.py
@@ -25,12 +25,13 @@ Usage::
     db  = mongo_manager["some_db"]["some_collection"]
 """
 
+import asyncio
 import json
 import os
 import shutil
 from datetime import datetime
 from pathlib import Path
-from typing import Optional
+from typing import ClassVar, Optional
 
 from motor.motor_asyncio import (
     AsyncIOMotorClient,
@@ -49,10 +50,17 @@ GUILD_DB_PREFIX = "guild_"
 
 
 class MongoManager:
-    """Singleton-style global MongoDB connection manager using motor (async)."""
+    """Singleton-style global MongoDB connection manager using motor (async).
+
+    Keeps one motor client *per event loop*: motor pins each client to the
+    loop that first uses it, so sharing a single client between the bot loop
+    and the Web UI's uvicorn loop (daemon thread) raises ``got Future
+    attached to a different loop``. In practice there are at most two
+    clients (bot + webui).
+    """
 
     _instance: Optional["MongoManager"] = None
-    _client: AsyncIOMotorClient | None = None
+    _clients: ClassVar[dict[asyncio.AbstractEventLoop | None, AsyncIOMotorClient]] = {}
     _url: str | None = None
 
     def __new__(cls) -> "MongoManager":
@@ -60,9 +68,18 @@ class MongoManager:
             cls._instance = super().__new__(cls)
         return cls._instance
 
+    @staticmethod
+    def _current_loop() -> asyncio.AbstractEventLoop | None:
+        try:
+            return asyncio.get_running_loop()
+        except RuntimeError:
+            return None
+
     def _ensure_client(self) -> AsyncIOMotorClient:
-        """Lazily create the motor client on first access."""
-        if self._client is None:
+        """Lazily create the motor client bound to the current event loop."""
+        loop = self._current_loop()
+        client = self._clients.get(loop)
+        if client is None:
             if self._url is None:
                 try:
                     config, _, _ = load_config()
@@ -76,12 +93,18 @@ class MongoManager:
                     "MongoDB URL is not configured. Set 'mongodb.url' in your configuration."
                 )
 
-            self._client = AsyncIOMotorClient(
+            client = AsyncIOMotorClient(
                 self._url,
                 serverSelectionTimeoutMS=5000,
+                connectTimeoutMS=10000,
+                socketTimeoutMS=60000,
+                maxPoolSize=50,
+                minPoolSize=1,
+                maxIdleTimeMS=300000,
             )
-            logger.info("Motor async MongoDB client created.")
-        return self._client
+            self._clients[loop] = client
+            logger.info("Motor async MongoDB client created (%d active).", len(self._clients))
+        return client
 
     # ------------------------------------------------------------------
     # Public helpers
@@ -136,11 +159,12 @@ class MongoManager:
             return False
 
     async def close(self) -> None:
-        """Close the motor client."""
-        if self._client is not None:
-            self._client.close()
-            self._client = None
-            logger.info("MongoDB connection closed.")
+        """Close every motor client (one per event loop)."""
+        if self._clients:
+            for client in self._clients.values():
+                client.close()
+            self._clients.clear()
+            logger.info("MongoDB connection(s) closed.")
 
     # ------------------------------------------------------------------
     # Backup

--- a/src/core/http.py
+++ b/src/core/http.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import random
 from typing import Any
 from urllib.parse import urlsplit, urlunsplit
 
@@ -112,6 +113,14 @@ class HttpClient:
 # Global singleton — import and reuse everywhere.
 http_client = HttpClient()
 
+# Cap on a single backoff sleep so high retry counts can't stall a task.
+_MAX_BACKOFF_SECONDS = 30.0
+
+
+def _backoff_delay(pause: float, attempt: int) -> float:
+    """Exponential backoff with jitter: ``pause * 2**attempt`` capped at 30s."""
+    return min(pause * 2.0**attempt, _MAX_BACKOFF_SECONDS) + random.uniform(0, pause)
+
 
 async def fetch(
     url: str,
@@ -126,7 +135,8 @@ async def fetch(
     Behaviour intentionally matches the legacy ``src.utils.fetch``:
 
     - Retries up to *retries* times on 5xx responses, ``ClientError``, and
-      ``asyncio.TimeoutError``. Linear backoff: ``pause * (attempt + 1)``.
+      ``asyncio.TimeoutError``. Exponential backoff with jitter:
+      ``pause * 2**attempt`` (capped at 30s) plus up to *pause* of jitter.
     - A non-500 non-200 response is not retried.
     - On final failure raises :class:`src.core.errors.HttpError` (subclass of
       :class:`Exception`, so existing ``except Exception:`` sites still catch).
@@ -156,7 +166,7 @@ async def fetch(
                 if response.status >= 500:
                     logger.error("Failed to fetch %s: Status %s", safe_url, response.status)
                     if attempt < retries - 1:
-                        await asyncio.sleep(pause * (attempt + 1))
+                        await asyncio.sleep(_backoff_delay(pause, attempt))
                         continue
                     raise HttpError(
                         f"Failed to fetch {safe_url}",
@@ -181,7 +191,7 @@ async def fetch(
                     url=url,
                     status=last_status,
                 ) from e
-            await asyncio.sleep(pause)
+            await asyncio.sleep(_backoff_delay(pause, attempt))
 
     # Loop exits only on repeated retryable 5xx without raising — guard rail.
     raise HttpError(f"Failed to fetch {safe_url}", url=url, status=last_status)

--- a/src/discord_ext/paginator.py
+++ b/src/discord_ext/paginator.py
@@ -8,6 +8,7 @@
 
 from __future__ import annotations
 
+import time
 from collections import defaultdict
 
 from interactions import ComponentContext, Message
@@ -52,10 +53,22 @@ class CustomPaginator(paginators.Paginator):
 # Poll formatter
 # ---------------------------------------------------------------------------
 
-# Per-guild cache of Discord-id → display-name overrides. Populated lazily from
-# the ``discord2name`` config mapping; keeps ``format_poll`` from hitting the
-# JSON file on every reaction.
+# Per-guild cache of the ``discord2name`` id → display-name overrides. Keeps
+# ``format_poll`` from hitting the JSON file on every reaction while still
+# picking up config edits after the TTL; entries are bounded by guild count.
 name_cache: dict[str, dict[str, str]] = {}
+_name_cache_loaded_at: dict[str, float] = {}
+_NAME_CACHE_TTL_SECONDS = 600.0
+
+
+def _guild_name_overrides(server_id: str) -> dict[str, str]:
+    """Return the discord2name mapping for a guild, reloading it after the TTL."""
+    now = time.monotonic()
+    loaded_at = _name_cache_loaded_at.get(server_id)
+    if loaded_at is None or now - loaded_at > _NAME_CACHE_TTL_SECONDS:
+        name_cache[server_id] = load_discord2name(server_id)
+        _name_cache_loaded_at[server_id] = now
+    return name_cache[server_id]
 
 
 async def format_poll(event: MessageReactionAdd | MessageReactionRemove):
@@ -87,6 +100,8 @@ async def format_poll(event: MessageReactionAdd | MessageReactionRemove):
         {user.id for users in reaction_users.values() for user in users} - {message.author.id}
     )
 
+    overrides = _guild_name_overrides(str(event.message.guild.id))
+
     description_list = []
     for _i, option in enumerate(options):
         option = option.split(":", 1)[0].replace("**", "")
@@ -95,18 +110,7 @@ async def format_poll(event: MessageReactionAdd | MessageReactionRemove):
         reaction_count = reaction_counts[emoji_str]
         user_list = reaction_users[emoji_str]
 
-        user_names = []
-        for user in user_list:
-            user_name = user.display_name
-            user_id = str(user.id)
-            server_id = str(event.message.guild.id)
-            if server_id not in name_cache:
-                name_cache[server_id] = {}
-            if user_id not in name_cache[server_id]:
-                d2n = load_discord2name(server_id)
-                name_cache[server_id][user_id] = d2n.get(user_id, user_name)
-            user_name = name_cache[server_id][user_id]
-            user_names.append(user_name)
+        user_names = [overrides.get(str(user.id), user.display_name) for user in user_list]
         user_names_str = ", ".join(user_names)
 
         description = f"{option}"

--- a/tests/test_core_db.py
+++ b/tests/test_core_db.py
@@ -1,0 +1,57 @@
+"""Tests for the per-event-loop motor client management in MongoManager.
+
+Motor pins each client to the event loop that first uses it, so the manager
+must hand out a distinct client per loop (bot loop vs. Web UI uvicorn loop)
+or cross-loop awaits fail with "got Future attached to a different loop".
+No MongoDB server is required: clients are created lazily and never queried.
+"""
+
+import asyncio
+
+import pytest
+
+from src.core.db import MongoManager, mongo_manager
+
+
+@pytest.fixture
+def isolated_manager():
+    """Point the singleton at a dummy URL and restore its state afterwards."""
+    saved_clients = dict(MongoManager._clients)
+    saved_url = mongo_manager._url
+    MongoManager._clients.clear()
+    mongo_manager._url = "mongodb://localhost:27017"
+    yield mongo_manager
+    for client in MongoManager._clients.values():
+        client.close()
+    MongoManager._clients.clear()
+    MongoManager._clients.update(saved_clients)
+    mongo_manager._url = saved_url
+
+
+def test_same_loop_reuses_client(isolated_manager):
+    async def grab_twice():
+        return isolated_manager._ensure_client(), isolated_manager._ensure_client()
+
+    first, second = asyncio.run(grab_twice())
+    assert first is second
+
+
+def test_distinct_loops_get_distinct_clients(isolated_manager):
+    async def grab():
+        return isolated_manager._ensure_client()
+
+    # asyncio.run creates a fresh event loop each call.
+    first = asyncio.run(grab())
+    second = asyncio.run(grab())
+    assert first is not second
+    assert len(MongoManager._clients) == 2
+
+
+def test_close_clears_all_clients(isolated_manager):
+    async def grab():
+        return isolated_manager._ensure_client()
+
+    asyncio.run(grab())
+    asyncio.run(grab())
+    asyncio.run(isolated_manager.close())
+    assert not MongoManager._clients

--- a/tests/test_core_http.py
+++ b/tests/test_core_http.py
@@ -1,0 +1,15 @@
+"""Tests for the HTTP retry backoff schedule."""
+
+from src.core.http import _MAX_BACKOFF_SECONDS, _backoff_delay
+
+
+def test_backoff_grows_exponentially():
+    # Jitter adds at most `pause` on top of the exponential base.
+    for attempt, base in [(0, 1), (1, 2), (2, 4), (3, 8)]:
+        delay = _backoff_delay(1, attempt)
+        assert base <= delay <= base + 1
+
+
+def test_backoff_is_capped():
+    delay = _backoff_delay(10, 10)  # 10 * 2**10 ≫ cap
+    assert delay <= _MAX_BACKOFF_SECONDS + 10


### PR DESCRIPTION
## Dashboard 500 on `/api/servers/{id}/infractions`

Motor pins each client to the event loop that **first uses it**, and `MongoManager` shared a single client process-wide. The bot touches Mongo first, so the client binds to the bot loop — then any WebUI route awaiting a repository from uvicorn's daemon-thread loop fails with `got Future attached to a different loop`, surfacing as HTTP 500 on the moderation infractions view (and latently on `GET /rolemenus` and infraction revoke).

`MongoManager` now keeps **one motor client per event loop** (bot + webui in practice) and closes them all on shutdown. All repositories work unchanged from either loop, including standalone webui mode. Covered by `tests/test_core_db.py`.

## Connection pool settings

The motor client now sets `maxPoolSize=50`, `minPoolSize=1`, `maxIdleTimeMS=300000`, `connectTimeoutMS=10000`, `socketTimeoutMS=60000` instead of driver defaults.

## Small reliability fixes

- **`src/core/http.py`** — retry backoff is now exponential with jitter (`pause * 2**attempt`, capped at 30 s) instead of linear; repeated API outages back off instead of hammering.
- **`extensions/zevent`** — `check_and_send_milestone` is serialized behind an `asyncio.Lock`, so overlapping refresh runs can't announce the same milestone twice.
- **`src/discord_ext/paginator.py`** — the `discord2name` poll-name cache reloads per guild after a 10-minute TTL instead of growing unbounded per user and never seeing config edits.
- **`extensions/zunivers`** — `/corpo` registers on `enabled_servers` instead of hardcoded guild `668445729928249344`; the 22 h journa reminder mentions the new `journaReminderRoleId` config field instead of hardcoded role `934560421912911882`.

> ⚠️ **Action needed after deploy:** set *Rôle rappel /journa* in the dashboard (module Zunivers) to keep the role ping — until then the reminder is sent without a mention.

## Checks

`ruff check` / `ruff format --check` ✅ · `mypy src` ✅ · `pytest` 49 passed (5 new)

https://claude.ai/code/session_013YC9RjMQVzzuyq3S3BzVYT

---
_Generated by [Claude Code](https://claude.ai/code/session_013YC9RjMQVzzuyq3S3BzVYT)_