### PR TITLE
webui: surface config write failures (module toggle/save 500s) + wipe guard

### DIFF
--- a/src/core/config.py
+++ b/src/core/config.py
@@ -68,6 +68,25 @@ def _atomic_write(data: dict[str, Any]) -> None:
         raise
 
 
+def config_write_error() -> str | None:
+    """Probe whether the config directory accepts new files.
+
+    Atomic writes create a tempfile next to ``config.json``, so they need
+    write permission on the *directory* — a bind mount owned by another uid
+    breaks saves even when the file itself is readable. Returns a
+    human-readable error string, or ``None`` when writable.
+    """
+    directory = os.path.dirname(CONFIG_PATH) or "."
+    try:
+        os.makedirs(directory, exist_ok=True)
+        fd, tmp_path = tempfile.mkstemp(prefix=".writetest-", suffix=".tmp", dir=directory)
+        os.close(fd)
+        os.unlink(tmp_path)
+        return None
+    except OSError as e:
+        return f"{type(e).__name__}: {e}"
+
+
 # ---------------------------------------------------------------------------
 # Reactive store — new in Phase 1
 # ---------------------------------------------------------------------------

--- a/src/webui/app.py
+++ b/src/webui/app.py
@@ -10,6 +10,7 @@ first.
 from fastapi import FastAPI
 
 from src.core import logging as logutil
+from src.core.config import config_write_error
 from src.core.config import load_config as bot_load_config
 from src.webui.auth import DiscordOAuth
 from src.webui.context import WebUIContext
@@ -54,6 +55,14 @@ def create_app(bot=None, bot_loop=None) -> FastAPI:
         bot_loop: The event loop the bot runs on — required to invoke bot
             coroutines from the WebUI's thread.
     """
+    write_err = config_write_error()
+    if write_err:
+        logger.error(
+            "Le dossier config/ n'est pas inscriptible (%s) — toutes les sauvegardes du "
+            "dashboard échoueront. Sur l'hôte : chown -R 1000:1000 ./config",
+            write_err,
+        )
+
     config, _, _ = bot_load_config()
     webui_config = config.get("webui", {})
     discord_config = config.get("discord", {})

--- a/src/webui/context.py
+++ b/src/webui/context.py
@@ -18,7 +18,10 @@ from typing import Any
 
 from fastapi import HTTPException, Request
 
+from src.core import logging as logutil
 from src.webui.auth import DiscordOAuth, Session
+
+logger = logutil.init_logger("webui.context")
 
 COOKIE_NAME = "michel_session"
 
@@ -53,10 +56,35 @@ class WebUIContext:
         return load_full_config() or {"config": {}, "servers": {}}
 
     def save_config(self, data: dict) -> None:
-        """Persist *data* atomically and notify ConfigStore subscribers."""
+        """Persist *data* atomically and notify ConfigStore subscribers.
+
+        Raises an ``HTTPException`` carrying the underlying cause so dashboard
+        saves surface an actionable message instead of a blind 500.
+        """
         from src.core.config import config_store
 
-        config_store.save_full(data)
+        if not data.get("config") and not data.get("servers"):
+            # An empty payload means the config file was unreadable when the
+            # request loaded it — saving would wipe the real config.
+            raise HTTPException(
+                status_code=503,
+                detail=(
+                    "Configuration en mémoire vide (fichier illisible ?) — "
+                    "sauvegarde refusée pour ne pas écraser config/config.json."
+                ),
+            )
+
+        try:
+            config_store.save_full(data)
+        except Exception as e:
+            logger.exception("Config save failed")
+            detail = f"Échec d'écriture de config/config.json : {e}"
+            if isinstance(e, PermissionError):
+                detail += (
+                    " — le dossier config/ n'est pas inscriptible par l'utilisateur du "
+                    "conteneur (uid 1000). Sur l'hôte : chown -R 1000:1000 ./config"
+                )
+            raise HTTPException(status_code=500, detail=detail) from e
 
     # --- Session / authorization -------------------------------------
 

--- a/src/webui/routes/servers.py
+++ b/src/webui/routes/servers.py
@@ -312,7 +312,9 @@ def create_router(ctx: WebUIContext) -> APIRouter:
         if server_id not in data.get("servers", {}):
             data.setdefault("servers", {})[server_id] = {}
 
-        if module_name not in data["servers"][server_id]:
+        # Hand-edited configs may hold a non-dict value here; replace it
+        # rather than crashing on the item assignment below.
+        if not isinstance(data["servers"][server_id].get(module_name), dict):
             data["servers"][server_id][module_name] = {}
 
         data["servers"][server_id][module_name]["enabled"] = body.enabled

--- a/tests/test_webui_save_config.py
+++ b/tests/test_webui_save_config.py
@@ -1,0 +1,48 @@
+"""Tests for WebUIContext.save_config failure handling.
+
+Dashboard saves must surface the underlying write error (e.g. a config/
+bind mount the container uid cannot write to) and must refuse to persist
+an empty config skeleton produced by an unreadable config file.
+"""
+
+import pytest
+from fastapi import HTTPException
+
+from src.webui.auth import DiscordOAuth
+from src.webui.context import WebUIContext
+
+
+@pytest.fixture
+def ctx():
+    oauth = DiscordOAuth(client_id="", client_secret="", redirect_uri="")
+    return WebUIContext(bot=None, bot_loop=None, oauth=oauth)
+
+
+def test_save_refuses_empty_config(ctx):
+    with pytest.raises(HTTPException) as exc:
+        ctx.save_config({})
+    assert exc.value.status_code == 503
+    assert "refusée" in exc.value.detail
+
+
+def test_save_surfaces_permission_error(ctx, monkeypatch):
+    from src.core.config import config_store
+
+    def boom(_data):
+        raise PermissionError(13, "Permission denied", "config/.config-x.json.tmp")
+
+    monkeypatch.setattr(config_store, "save_full", boom)
+    with pytest.raises(HTTPException) as exc:
+        ctx.save_config({"config": {"x": 1}, "servers": {}})
+    assert exc.value.status_code == 500
+    assert "Permission denied" in exc.value.detail
+    assert "chown -R 1000:1000" in exc.value.detail
+
+
+def test_save_passes_through_on_success(ctx, monkeypatch):
+    from src.core.config import config_store
+
+    saved = {}
+    monkeypatch.setattr(config_store, "save_full", saved.update)
+    ctx.save_config({"config": {"x": 1}, "servers": {}})
+    assert saved == {"config": {"x": 1}, "servers": {}}


### PR DESCRIPTION
## Context

Toggling/saving `moduleModeration` from the dashboard returns HTTP 500 (`POST …/modules/moduleModeration/toggle`, `PUT …/modules/moduleModeration`). The endpoint code path is clean (replayed locally end-to-end), and everything in those handlers is guarded **except** `config_store.save_full()` — whose only unguarded failure mode is the filesystem write. Atomic config writes create a tempfile *next to* `config.json`, so they need write permission on the `config/` **directory**; with the container running as uid 1000 and `./config` bind-mounted, a host directory owned by another user makes every dashboard save fail while reads keep working. The dashboard then shows a blind 500 with no clue.

This PR doesn't change what can fail — it makes the failure visible and safe:

- **`WebUIContext.save_config`** wraps `save_full()` and raises an `HTTPException` whose `detail` carries the real error, with a `chown -R 1000:1000 ./config` hint when it's a `PermissionError`. The dashboard toast now shows the actual cause.
- **Wipe guard**: if `config.json` was unreadable when the request loaded it (`load_full_config()` returns `{}`), the save endpoints used to happily persist a near-empty skeleton — silently destroying the whole config. `save_config` now refuses with a 503 instead.
- **Startup probe**: `create_app()` checks config-directory writability (`config_write_error()` in `src/core/config.py`) and logs a loud, actionable error at boot if saves are doomed.
- **Toggle robustness**: `POST …/toggle` no longer crashes if a hand-edited config holds a non-dict module value.

## Checks

`ruff check` / `ruff format --check` ✅ · `mypy src` ✅ · `pytest` 52 passed (3 new in `tests/test_webui_save_config.py`)

## For the deployment itself

After deploying, the real cause will appear in the dashboard error toast and in the startup logs. If it is the expected permission issue, the fix on the host is:

```bash
ls -ld config/            # check owner — container user is uid 1000
sudo chown -R 1000:1000 config/
```

https://claude.ai/code/session_013YC9RjMQVzzuyq3S3BzVYT

---
_Generated by [Claude Code](https://claude.ai/code/session_013YC9RjMQVzzuyq3S3BzVYT)_