### PR TITLE
webui: auth hardening — persisted sessions, guarded OAuth exchange, state check, loopback bind

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,9 @@ services:
     container_name: discord_bot
     image: ghcr.io/lightd31/michel-discord-bot:latest
     ports:
-      - "8080:8080"
+      # Web UI bound to loopback only — front it with a reverse proxy
+      # (Caddy/Nginx/Traefik) for TLS. Use "8080:8080" to expose it directly.
+      - "127.0.0.1:8080:8080"
     environment:
       # Toggle extra debug logging (file/line in log records). Default off.
       MICHEL_DEBUG: "${MICHEL_DEBUG:-false}"

--- a/src/core/http.py
+++ b/src/core/http.py
@@ -23,7 +23,8 @@ from __future__ import annotations
 import asyncio
 import os
 import random
-from typing import Any
+import threading
+from typing import Any, ClassVar
 from urllib.parse import urlsplit, urlunsplit
 
 from aiohttp import ClientError, ClientSession, ClientTimeout
@@ -73,41 +74,55 @@ _DEFAULT_TIMEOUT = ClientTimeout(total=30)
 
 
 class HttpClient:
-    """Lazy singleton around a single ``aiohttp.ClientSession``.
+    """Lazy singleton handing out one ``aiohttp.ClientSession`` per event loop.
 
-    The session is created on first use inside the running event loop. Callers
-    should not close it — :meth:`close` is intended for shutdown hooks.
+    aiohttp sessions are bound to the loop they are created on, so sharing a
+    single session between the bot loop and the Web UI's uvicorn loop (daemon
+    thread) breaks — same constraint as ``src.core.db.MongoManager``. In
+    practice there are at most two sessions. Callers should not close them —
+    :meth:`close` is intended for shutdown hooks.
     """
 
     _instance: HttpClient | None = None
-    _session: ClientSession | None
-    _lock: asyncio.Lock
+    _sessions: ClassVar[dict[asyncio.AbstractEventLoop, ClientSession]] = {}
+    # ClientSession construction is synchronous, so a thread lock is enough to
+    # serialize creation across loops/threads (an asyncio.Lock would itself be
+    # bound to a single loop).
+    _create_lock: ClassVar[threading.Lock] = threading.Lock()
 
     def __new__(cls) -> HttpClient:
         if cls._instance is None:
             cls._instance = super().__new__(cls)
-            cls._instance._session = None
-            cls._instance._lock = asyncio.Lock()
         return cls._instance
 
     async def session(self) -> ClientSession:
-        """Return the shared session, creating it on first use."""
-        if self._session is None or self._session.closed:
-            async with self._lock:
-                if self._session is None or self._session.closed:
-                    self._session = ClientSession(
+        """Return the calling loop's shared session, creating it on first use."""
+        loop = asyncio.get_running_loop()
+        session = self._sessions.get(loop)
+        if session is None or session.closed:
+            with self._create_lock:
+                session = self._sessions.get(loop)
+                if session is None or session.closed:
+                    session = ClientSession(
                         timeout=_DEFAULT_TIMEOUT,
                         headers={"User-Agent": _DEFAULT_USER_AGENT},
                     )
-                    logger.info("Shared aiohttp ClientSession created.")
-        return self._session
+                    self._sessions[loop] = session
+                    logger.info(
+                        "Shared aiohttp ClientSession created (%d active).", len(self._sessions)
+                    )
+        return session
 
     async def close(self) -> None:
-        """Close the shared session. Call this during graceful shutdown."""
-        if self._session is not None and not self._session.closed:
-            await self._session.close()
+        """Close the calling loop's session. Call this during graceful shutdown.
+
+        Sessions owned by other loops must be closed from their own loop;
+        in practice they belong to daemon threads that die with the process.
+        """
+        session = self._sessions.pop(asyncio.get_running_loop(), None)
+        if session is not None and not session.closed:
+            await session.close()
             logger.info("Shared aiohttp ClientSession closed.")
-        self._session = None
 
 
 # Global singleton — import and reuse everywhere.

--- a/src/webui/app.py
+++ b/src/webui/app.py
@@ -7,6 +7,9 @@ The frontend catch-all router must be mounted **last** so API routes match
 first.
 """
 
+import asyncio
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
 
 from src.core import logging as logutil
@@ -46,6 +49,18 @@ from src.webui.sse import logs as logs_sse
 
 logger = logutil.init_logger("webui.app")
 
+# How often the background task evicts expired sessions (memory + MongoDB).
+_SESSION_CLEANUP_INTERVAL_SECONDS = 1800.0
+
+
+async def _session_cleanup_loop(oauth: DiscordOAuth) -> None:
+    while True:
+        await asyncio.sleep(_SESSION_CLEANUP_INTERVAL_SECONDS)
+        try:
+            await oauth.purge_expired()
+        except Exception as e:
+            logger.warning("Session cleanup tick failed: %s", e)
+
 
 def create_app(bot=None, bot_loop=None) -> FastAPI:
     """Create and configure the FastAPI application.
@@ -84,7 +99,24 @@ def create_app(bot=None, bot_loop=None) -> FastAPI:
     if not WebUILogHandler.get_instance():
         install_log_handler(max_entries=2000)
 
-    app = FastAPI(title="Michel Bot Dashboard", docs_url=None, redoc_url=None)
+    @asynccontextmanager
+    async def lifespan(_app: FastAPI):
+        # Runs on uvicorn's own loop: restore persisted sessions so a bot
+        # restart doesn't log every admin out, then keep them pruned.
+        try:
+            from src.webui.sessions import SessionRepository
+
+            await SessionRepository().ensure_indexes()
+        except Exception as e:
+            logger.warning("Web UI session TTL index setup failed: %s", e)
+        await oauth.restore_sessions()
+        cleanup_task = asyncio.create_task(_session_cleanup_loop(oauth))
+        try:
+            yield
+        finally:
+            cleanup_task.cancel()
+
+    app = FastAPI(title="Michel Bot Dashboard", docs_url=None, redoc_url=None, lifespan=lifespan)
 
     ctx = WebUIContext(bot=bot, bot_loop=bot_loop, oauth=oauth)
 

--- a/src/webui/auth.py
+++ b/src/webui/auth.py
@@ -4,11 +4,15 @@ Discord OAuth2 authentication for the Web UI.
 
 import secrets
 import time
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
+from typing import Any
+from urllib.parse import urlencode
 
-import aiohttp
+from aiohttp import ClientError
 
 from src.core import logging as logutil
+from src.core.http import http_client
+from src.webui.sessions import SessionRepository, expires_dt_from_ts
 
 logger = logutil.init_logger("webui.auth")
 
@@ -31,6 +35,27 @@ class Session:
     session_token: str = field(default_factory=lambda: secrets.token_urlsafe(32))
 
 
+def _session_to_doc(session: Session) -> dict[str, Any]:
+    """Serialize a session for MongoDB (``_id`` = token, TTL helper field)."""
+    doc = asdict(session)
+    doc["_id"] = doc.pop("session_token")
+    doc["expires_dt"] = expires_dt_from_ts(session.expires_at)
+    return doc
+
+
+def _doc_to_session(doc: dict[str, Any]) -> Session:
+    return Session(
+        user_id=doc["user_id"],
+        username=doc["username"],
+        avatar=doc.get("avatar"),
+        guilds=doc.get("guilds", []),
+        access_token=doc["access_token"],
+        refresh_token=doc.get("refresh_token", ""),
+        expires_at=float(doc["expires_at"]),
+        session_token=doc["_id"],
+    )
+
+
 class DiscordOAuth:
     """Handles Discord OAuth2 flow and session management."""
 
@@ -46,7 +71,6 @@ class DiscordOAuth:
         self.redirect_uri = redirect_uri
         self.developer_user_ids = developer_user_ids or []
         self.sessions: dict[str, Session] = {}
-        self._cleanup_counter = 0
 
     def get_oauth_url(self, state: str) -> str:
         """Generate the Discord OAuth2 authorization URL."""
@@ -57,12 +81,12 @@ class DiscordOAuth:
             "scope": "identify guilds",
             "state": state,
         }
-        query = "&".join(f"{k}={v}" for k, v in params.items())
-        return f"{DISCORD_OAUTH2_URL}?{query}"
+        return f"{DISCORD_OAUTH2_URL}?{urlencode(params)}"
 
     async def exchange_code(self, code: str) -> Session | None:
         """Exchange an authorization code for tokens and create a session."""
-        async with aiohttp.ClientSession() as http:
+        try:
+            http = await http_client.session()
             # Exchange code for token
             data = {
                 "client_id": self.client_id,
@@ -77,9 +101,10 @@ class DiscordOAuth:
                     return None
                 token_data = await resp.json()
 
-            access_token = token_data["access_token"]
-            refresh_token = token_data["refresh_token"]
-            expires_in = token_data["expires_in"]
+            access_token = token_data.get("access_token")
+            if not access_token:
+                logger.error("Token exchange response missing access_token")
+                return None
 
             # Get user info
             headers = {"Authorization": f"Bearer {access_token}"}
@@ -96,21 +121,46 @@ class DiscordOAuth:
                     guilds = []
                 else:
                     guilds = await resp.json()
+        except (TimeoutError, ClientError, ValueError) as e:
+            logger.error("OAuth code exchange failed: %s", e)
+            return None
 
-        session = Session(
-            user_id=user_data["id"],
-            username=user_data.get("global_name") or user_data["username"],
-            avatar=user_data.get("avatar"),
-            guilds=guilds,
-            access_token=access_token,
-            refresh_token=refresh_token,
-            expires_at=time.time() + expires_in,
-        )
+        session = self._session_from_payload(token_data, user_data, guilds)
+        if session is None:
+            return None
 
         self.sessions[session.session_token] = session
-        self._maybe_cleanup()
+        await self._persist(session)
         logger.info(f"User logged in: {session.username} ({session.user_id})")
         return session
+
+    @staticmethod
+    def _session_from_payload(
+        token_data: dict[str, Any],
+        user_data: dict[str, Any],
+        guilds: list,
+    ) -> Session | None:
+        """Build a Session from Discord's responses; None if a field is missing."""
+        access_token = token_data.get("access_token")
+        user_id = user_data.get("id")
+        if not access_token or not user_id:
+            logger.error("Discord OAuth payload incomplete (token or user id missing)")
+            return None
+        try:
+            expires_in = float(token_data.get("expires_in") or 0)
+        except (TypeError, ValueError):
+            expires_in = 0.0
+        if expires_in <= 0:
+            expires_in = 3600.0  # conservative fallback, Discord normally sends 7 days
+        return Session(
+            user_id=str(user_id),
+            username=user_data.get("global_name") or user_data.get("username") or str(user_id),
+            avatar=user_data.get("avatar"),
+            guilds=guilds if isinstance(guilds, list) else [],
+            access_token=access_token,
+            refresh_token=token_data.get("refresh_token", ""),
+            expires_at=time.time() + expires_in,
+        )
 
     def is_developer(self, session: Session) -> bool:
         """Check if a session user is a developer (has access to extensions and logs)."""
@@ -125,19 +175,58 @@ class DiscordOAuth:
             del self.sessions[session_token]
         return None
 
-    def invalidate_session(self, session_token: str):
-        """Remove a session."""
+    async def invalidate_session(self, session_token: str) -> None:
+        """Remove a session from memory and MongoDB."""
         self.sessions.pop(session_token, None)
+        try:
+            await SessionRepository().delete(session_token)
+        except Exception as e:
+            logger.warning("Could not delete persisted session: %s", e)
 
-    def _maybe_cleanup(self):
-        """Periodically clean up expired sessions."""
-        self._cleanup_counter += 1
-        if self._cleanup_counter >= 10:
-            self._cleanup_counter = 0
-            now = time.time()
-            expired = [k for k, v in self.sessions.items() if v.expires_at <= now]
-            for k in expired:
-                del self.sessions[k]
+    # --- Persistence (survive bot restarts) ---------------------------
+
+    async def _persist(self, session: Session) -> None:
+        """Best-effort write-through to MongoDB — never blocks a login."""
+        try:
+            await SessionRepository().upsert_doc(_session_to_doc(session))
+        except Exception as e:
+            logger.warning("Could not persist session to MongoDB: %s", e)
+
+    async def restore_sessions(self) -> int:
+        """Load persisted, unexpired sessions into memory (dashboard startup)."""
+        try:
+            docs = await SessionRepository().load_all_docs()
+        except Exception as e:
+            logger.warning("Could not restore Web UI sessions: %s", e)
+            return 0
+        now = time.time()
+        restored = 0
+        for doc in docs:
+            try:
+                session = _doc_to_session(doc)
+            except (KeyError, TypeError, ValueError) as e:
+                logger.warning("Skipping malformed persisted session: %s", e)
+                continue
+            if session.expires_at > now:
+                self.sessions[session.session_token] = session
+                restored += 1
+        if restored:
+            logger.info("Restored %d Web UI session(s) from MongoDB.", restored)
+        return restored
+
+    async def purge_expired(self) -> int:
+        """Drop expired sessions from memory and MongoDB; returns memory count."""
+        now = time.time()
+        expired = [k for k, v in self.sessions.items() if v.expires_at <= now]
+        for k in expired:
+            del self.sessions[k]
+        try:
+            await SessionRepository().delete_expired(now)
+        except Exception as e:
+            logger.debug("Persisted-session purge failed: %s", e)
+        if expired:
+            logger.info("Purged %d expired Web UI session(s).", len(expired))
+        return len(expired)
 
     def get_user_managed_guilds(self, session: Session) -> list[dict]:
         """

--- a/src/webui/routes/auth.py
+++ b/src/webui/routes/auth.py
@@ -41,6 +41,19 @@ def create_router(ctx: WebUIContext) -> APIRouter:
         if not code:
             raise HTTPException(status_code=400, detail="Code manquant")
 
+        # CSRF check: the state we sent must come back and match the cookie.
+        expected_state = request.cookies.get("oauth_state", "")
+        if not state or not expected_state or not secrets.compare_digest(expected_state, state):
+            rejection = HTMLResponse(
+                content=(
+                    "<h1>Connexion expirée</h1>"
+                    "<p>État OAuth invalide ou expiré — relance la connexion.</p>"
+                ),
+                status_code=403,
+            )
+            rejection.delete_cookie("oauth_state")
+            return rejection
+
         session = await ctx.oauth.exchange_code(code)
         if not session:
             return HTMLResponse(
@@ -65,7 +78,7 @@ def create_router(ctx: WebUIContext) -> APIRouter:
         """Logout and invalidate the session."""
         token = request.cookies.get(COOKIE_NAME)
         if token:
-            ctx.oauth.invalidate_session(token)
+            await ctx.oauth.invalidate_session(token)
         response = RedirectResponse(url="/")
         response.delete_cookie(COOKIE_NAME)
         return response

--- a/src/webui/sessions.py
+++ b/src/webui/sessions.py
@@ -1,0 +1,48 @@
+"""MongoDB persistence for Web UI sessions.
+
+Sessions previously lived only in :attr:`DiscordOAuth.sessions`, so every bot
+restart logged all admins out. This repository mirrors that dict in the
+``global`` database (collection ``webui_sessions``): logins/logouts write
+through, and the whole collection is loaded back into memory when the
+dashboard starts. A TTL index on ``expires_dt`` lets MongoDB drop expired
+documents on its own even if the periodic purge never runs.
+
+Documents are raw dicts (``_id`` = session token) — (de)serialization to the
+:class:`~src.webui.auth.Session` dataclass lives in ``src.webui.auth`` to keep
+this module free of webui imports.
+"""
+
+from datetime import UTC, datetime
+from typing import Any
+
+from src.core.db import mongo_manager
+
+COLLECTION = "webui_sessions"
+
+
+class SessionRepository:
+    """Global-database store for dashboard sessions."""
+
+    def _col(self):
+        return mongo_manager.get_global_collection(COLLECTION)
+
+    async def ensure_indexes(self) -> None:
+        await self._col().create_index("expires_dt", expireAfterSeconds=0, name="expires_ttl")
+
+    async def upsert_doc(self, doc: dict[str, Any]) -> None:
+        await self._col().replace_one({"_id": doc["_id"]}, doc, upsert=True)
+
+    async def delete(self, session_token: str) -> None:
+        await self._col().delete_one({"_id": session_token})
+
+    async def delete_expired(self, now_ts: float) -> int:
+        result = await self._col().delete_many({"expires_at": {"$lte": now_ts}})
+        return int(result.deleted_count)
+
+    async def load_all_docs(self) -> list[dict[str, Any]]:
+        return [doc async for doc in self._col().find()]
+
+
+def expires_dt_from_ts(expires_at: float) -> datetime:
+    """Timestamp → aware datetime for the TTL index field."""
+    return datetime.fromtimestamp(expires_at, tz=UTC)

--- a/tests/test_webui_auth.py
+++ b/tests/test_webui_auth.py
@@ -1,0 +1,231 @@
+"""Tests for the Web UI auth hardening.
+
+Covers: OAuth URL encoding, guarded session construction from Discord
+payloads, MongoDB (de)serialization round-trip, per-event-loop aiohttp
+sessions, OAuth state (CSRF) validation in the callback, and the
+restore/purge persistence glue (with a stubbed repository — no MongoDB).
+"""
+
+import asyncio
+import time
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
+from starlette.requests import Request
+
+import src.webui.auth as auth_module
+from src.core.http import http_client
+from src.webui.auth import (
+    DiscordOAuth,
+    Session,
+    _doc_to_session,
+    _session_to_doc,
+)
+from src.webui.context import WebUIContext
+from src.webui.routes import auth as auth_routes
+
+
+def make_oauth(**kwargs) -> DiscordOAuth:
+    defaults = {
+        "client_id": "123",
+        "client_secret": "s3cret",
+        "redirect_uri": "https://michel.example/auth/callback",
+    }
+    defaults.update(kwargs)
+    return DiscordOAuth(**defaults)
+
+
+def make_session(expires_in: float = 3600.0, **kwargs) -> Session:
+    defaults = {
+        "user_id": "42",
+        "username": "michel",
+        "avatar": None,
+        "guilds": [{"id": "1", "permissions": "32"}],
+        "access_token": "at",
+        "refresh_token": "rt",
+        "expires_at": time.time() + expires_in,
+    }
+    defaults.update(kwargs)
+    return Session(**defaults)
+
+
+# ── OAuth URL ───────────────────────────────────────────────────────────
+
+
+def test_oauth_url_is_properly_encoded():
+    url = make_oauth().get_oauth_url(state="a/b c")
+    parts = urlsplit(url)
+    query = parse_qs(parts.query)
+    assert query["redirect_uri"] == ["https://michel.example/auth/callback"]
+    assert query["state"] == ["a/b c"]
+    assert "redirect_uri=https://" not in url  # the raw URI must be escaped
+
+
+# ── Payload guards ──────────────────────────────────────────────────────
+
+
+def test_session_from_payload_requires_token_and_id():
+    build = DiscordOAuth._session_from_payload
+    assert build({}, {"id": "1"}, []) is None
+    assert build({"access_token": "at"}, {}, []) is None
+
+
+def test_session_from_payload_tolerates_partial_data():
+    session = DiscordOAuth._session_from_payload(
+        {"access_token": "at", "expires_in": "oops"},
+        {"id": 42},
+        "not-a-list",
+    )
+    assert session is not None
+    assert session.user_id == "42"
+    assert session.username == "42"  # falls back to the id
+    assert session.refresh_token == ""
+    assert session.guilds == []
+    assert session.expires_at > time.time()
+
+
+# ── Mongo (de)serialization ─────────────────────────────────────────────
+
+
+def test_session_doc_round_trip():
+    session = make_session()
+    doc = _session_to_doc(session)
+    assert doc["_id"] == session.session_token
+    assert "session_token" not in doc
+    restored = _doc_to_session(doc)
+    assert restored == session
+
+
+# ── Per-loop aiohttp sessions ───────────────────────────────────────────
+
+
+def test_http_client_one_session_per_loop():
+    async def grab():
+        first = await http_client.session()
+        second = await http_client.session()
+        assert second is first
+        await http_client.close()
+        return first
+
+    a = asyncio.run(grab())
+    b = asyncio.run(grab())  # fresh loop → fresh session
+    assert a is not b
+
+
+# ── Callback state (CSRF) validation ────────────────────────────────────
+#
+# The route endpoint is invoked directly with a hand-built starlette Request
+# (no TestClient — it drags in an HTTP client dependency for no benefit here).
+
+
+def get_callback_endpoint():
+    oauth = make_oauth()
+
+    async def fake_exchange(code: str):
+        return make_session() if code == "good-code" else None
+
+    oauth.exchange_code = fake_exchange
+    ctx = WebUIContext(bot=None, bot_loop=None, oauth=oauth)
+    router = auth_routes.create_router(ctx)
+    route = next(r for r in router.routes if r.path == "/auth/callback")
+    return route.endpoint
+
+
+def make_request(state_cookie: str | None) -> Request:
+    headers = []
+    if state_cookie is not None:
+        headers.append((b"cookie", f"oauth_state={state_cookie}".encode()))
+    return Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "scheme": "http",
+            "path": "/auth/callback",
+            "query_string": b"",
+            "headers": headers,
+        }
+    )
+
+
+def call_callback(state_cookie: str | None, state: str):
+    endpoint = get_callback_endpoint()
+    return asyncio.run(endpoint(make_request(state_cookie), code="good-code", state=state))
+
+
+def test_callback_rejects_mismatched_state():
+    resp = call_callback(state_cookie="expected", state="tampered")
+    assert resp.status_code == 403
+
+
+def test_callback_rejects_missing_state_cookie():
+    resp = call_callback(state_cookie=None, state="whatever")
+    assert resp.status_code == 403
+
+
+def test_callback_accepts_matching_state():
+    resp = call_callback(state_cookie="expected", state="expected")
+    assert resp.status_code == 307  # redirect home with the session cookie
+    set_cookie = ",".join(resp.headers.getlist("set-cookie"))
+    assert "michel_session=" in set_cookie
+
+
+# ── Persistence glue (stubbed repository) ───────────────────────────────
+
+
+class StubRepo:
+    docs: list[dict] = []
+    deleted: list[str] = []
+
+    async def load_all_docs(self):
+        return list(self.docs)
+
+    async def upsert_doc(self, doc):
+        self.docs.append(doc)
+
+    async def delete(self, token):
+        self.deleted.append(token)
+
+    async def delete_expired(self, now_ts):
+        return 0
+
+
+@pytest.fixture
+def stub_repo(monkeypatch):
+    StubRepo.docs = []
+    StubRepo.deleted = []
+    monkeypatch.setattr(auth_module, "SessionRepository", StubRepo)
+    return StubRepo
+
+
+def test_restore_skips_expired_sessions(stub_repo):
+    fresh = make_session(expires_in=3600)
+    stale = make_session(expires_in=-60)
+    stub_repo.docs = [_session_to_doc(fresh), _session_to_doc(stale)]
+
+    oauth = make_oauth()
+    restored = asyncio.run(oauth.restore_sessions())
+    assert restored == 1
+    assert oauth.get_session(fresh.session_token) is not None
+    assert oauth.get_session(stale.session_token) is None
+
+
+def test_purge_expired_evicts_memory(stub_repo):
+    oauth = make_oauth()
+    fresh = make_session(expires_in=3600)
+    stale = make_session(expires_in=-60)
+    oauth.sessions = {s.session_token: s for s in (fresh, stale)}
+
+    purged = asyncio.run(oauth.purge_expired())
+    assert purged == 1
+    assert fresh.session_token in oauth.sessions
+    assert stale.session_token not in oauth.sessions
+
+
+def test_invalidate_session_removes_everywhere(stub_repo):
+    oauth = make_oauth()
+    session = make_session()
+    oauth.sessions[session.session_token] = session
+
+    asyncio.run(oauth.invalidate_session(session.session_token))
+    assert session.session_token not in oauth.sessions
+    assert stub_repo.deleted == [session.session_token]

--- a/tests/test_webui_auth.py
+++ b/tests/test_webui_auth.py
@@ -28,7 +28,7 @@ from src.webui.routes import auth as auth_routes
 def make_oauth(**kwargs) -> DiscordOAuth:
     defaults = {
         "client_id": "123",
-        "client_secret": "s3cret",
+        "client_secret": "s3cret",  # pragma: allowlist secret
         "redirect_uri": "https://michel.example/auth/callback",
     }
     defaults.update(kwargs)


### PR DESCRIPTION
## Web UI auth hardening

The four items from the improvement analysis, plus one fix found on the way.

### Sessions survive restarts
`DiscordOAuth` keeps its in-memory dict (so `get_session` stays sync for all routes) but now mirrors it to MongoDB (`global.webui_sessions`, TTL index on `expires_dt`). The FastAPI lifespan restores unexpired sessions at dashboard startup, so a redeploy no longer logs every admin out. All persistence is best-effort — MongoDB being down never blocks a login, it just falls back to memory-only.

### Guarded `exchange_code()`
Discord's token/user payloads are no longer indexed blind (`KeyError` → 500 on any odd response). Missing fields log and return `None`; network/JSON errors are caught. Session construction moved to `_session_from_payload()`, unit-tested against partial payloads.

### Shared HTTP client (with a twist)
`exchange_code` now uses the shared client from `src.core.http` instead of a throwaway `ClientSession` per login. Because aiohttp sessions are loop-bound and the webui runs on its own uvicorn loop, `HttpClient` was first made **per-event-loop** — the exact pattern shipped for `MongoManager` in #58. Without that, reusing the shared session from the webui would have recreated the cross-loop bug.

### Background session cleanup
The every-10th-request cleanup counter is replaced by a 30-minute background task started in the lifespan (memory + MongoDB), with the Mongo TTL index as a backstop.

### Loopback binding
`docker-compose.yml` now publishes `127.0.0.1:8080:8080` with a comment pointing at the reverse-proxy setup. ⚠️ If your reverse proxy reaches the dashboard via the host's public IP rather than localhost (or runs in a container using the published port from another host), adjust accordingly — host-local proxies (Caddy/Nginx on the same machine) are unaffected.

### Bonus: the `state` cookie is now actually checked
The analysis assumed the CSRF state cookie was verified — it was *set* on login and *deleted* on callback, but never compared. The callback now validates it with a constant-time compare and rejects mismatches with a 403 (the Spotify OAuth flow next door already did this correctly). The authorize URL is also built with `urlencode` instead of raw f-string interpolation.

## Checks

`ruff check` / `ruff format --check` ✅ · `mypy src` ✅ · `pytest` 63 passed (11 new in `tests/test_webui_auth.py`)

## Noted for a future batch (not in this PR)

Authorization is currently all-or-nothing: `require_admin` = "manages ≥ 1 guild the bot is in", which grants read/write on **every** guild's config, infractions and role menus — and `GET /api/config` / `/api/global-config` expose the bot token and all secrets at that same level. Per-guild checks (`require_guild_admin(server_id)`) and developer-only global config would close that; say the word and I'll do it as its own PR since it needs matching dashboard gating.

https://claude.ai/code/session_013YC9RjMQVzzuyq3S3BzVYT

---
_Generated by [Claude Code](https://claude.ai/code/session_013YC9RjMQVzzuyq3S3BzVYT)_