### PR TITLE
webui: per-guild authorization + developer-only global config

### DIFF
--- a/src/webui/context.py
+++ b/src/webui/context.py
@@ -102,6 +102,8 @@ class WebUIContext:
 
     def is_admin_user(self, session: Session) -> bool:
         """Admin if user has MANAGE_GUILD/ADMINISTRATOR on any bot guild."""
+        if self.oauth.is_developer(session):
+            return True
         if self.bot and self.bot.guilds:
             bot_guild_ids = {str(g.id) for g in self.bot.guilds}
             managed = self.oauth.get_user_managed_guilds(session)
@@ -112,6 +114,22 @@ class WebUIContext:
         session = self.require_session(request)
         if not self.is_admin_user(session):
             raise HTTPException(status_code=403, detail="Accès réservé aux administrateurs")
+        return session
+
+    def user_manages_guild(self, session: Session, guild_id: str | int) -> bool:
+        """True if the user owns/administers/manages *this* guild (or is developer)."""
+        if self.oauth.is_developer(session):
+            return True
+        managed = {g["id"] for g in self.oauth.get_user_managed_guilds(session)}
+        return str(guild_id) in managed
+
+    def require_guild_admin(self, request: Request, guild_id: str | int) -> Session:
+        """Per-guild authorization — managing one guild grants nothing on the others."""
+        session = self.require_session(request)
+        if not self.user_manages_guild(session, guild_id):
+            raise HTTPException(
+                status_code=403, detail="Accès réservé aux administrateurs de ce serveur"
+            )
         return session
 
     def require_developer(self, request: Request) -> Session:

--- a/src/webui/routes/config.py
+++ b/src/webui/routes/config.py
@@ -21,8 +21,8 @@ def create_router(ctx: WebUIContext) -> APIRouter:
 
     @router.get("/api/config")
     async def api_get_config(request: Request):
-        """Get the full configuration."""
-        ctx.require_admin(request)
+        """Get the full configuration (contains secrets — developer only)."""
+        ctx.require_developer(request)
         data = ctx.get_full_config()
         return JSONResponse(data)
 
@@ -65,15 +65,15 @@ def create_router(ctx: WebUIContext) -> APIRouter:
 
     @router.get("/api/global-config")
     async def api_get_global_config(request: Request):
-        """Get global (non-server-specific) configuration."""
-        ctx.require_admin(request)
+        """Get global configuration (contains secrets — developer only)."""
+        ctx.require_developer(request)
         data = ctx.get_full_config()
         return JSONResponse(data.get("config", {}))
 
     @router.put("/api/global-config/{section}")
     async def api_update_global_config(request: Request, section: str, body: GlobalConfigUpdate):
-        """Update a section of the global configuration."""
-        ctx.require_admin(request)
+        """Update a section of the global configuration (developer only)."""
+        ctx.require_developer(request)
         data = ctx.get_full_config()
         data.setdefault("config", {})[section] = body.config
         ctx.save_config(data)
@@ -87,7 +87,7 @@ def create_router(ctx: WebUIContext) -> APIRouter:
         Query params:
             dry_run: if true, return what would be removed without saving.
         """
-        ctx.require_admin(request)
+        ctx.require_developer(request)
         data = ctx.get_full_config()
         removed: list[dict] = []
 

--- a/src/webui/routes/moderation.py
+++ b/src/webui/routes/moderation.py
@@ -51,7 +51,7 @@ def create_router(ctx: WebUIContext) -> APIRouter:
         type: str | None = Query(default=None),
         active: str | None = Query(default=None),
     ):
-        ctx.require_admin(request)
+        ctx.require_guild_admin(request, server_id)
         active_filter: bool | None = None
         if active in ("true", "1"):
             active_filter = True
@@ -72,7 +72,7 @@ def create_router(ctx: WebUIContext) -> APIRouter:
 
     @router.delete("/api/servers/{server_id}/infractions/{case_id}")
     async def api_revoke_infraction(request: Request, server_id: str, case_id: int):
-        ctx.require_admin(request)
+        ctx.require_guild_admin(request, server_id)
         repo = ModerationRepository(server_id)
         try:
             existing = await repo.get(case_id)

--- a/src/webui/routes/rolemenus.py
+++ b/src/webui/routes/rolemenus.py
@@ -120,7 +120,7 @@ def create_router(ctx: WebUIContext) -> APIRouter:
     @router.get("/api/servers/{server_id}/roles")
     async def api_list_roles(request: Request, server_id: str):
         """List assignable roles in a guild (for the role-picker)."""
-        ctx.require_admin(request)
+        ctx.require_guild_admin(request, server_id)
 
         async def _fetch():
             try:
@@ -165,7 +165,7 @@ def create_router(ctx: WebUIContext) -> APIRouter:
 
     @router.get("/api/servers/{server_id}/rolemenus")
     async def api_list_rolemenus(request: Request, server_id: str):
-        ctx.require_admin(request)
+        ctx.require_guild_admin(request, server_id)
         repo = ReactionRolesRepository(server_id)
         try:
             menus = await repo.list()
@@ -176,7 +176,7 @@ def create_router(ctx: WebUIContext) -> APIRouter:
 
     @router.post("/api/servers/{server_id}/rolemenus")
     async def api_create_rolemenu(request: Request, server_id: str, body: RoleMenuCreate):
-        session = ctx.require_admin(request)
+        session = ctx.require_guild_admin(request, server_id)
 
         async def _create():
             guild, channel = await _resolve_guild_and_channel(ctx.bot, server_id, body.channel_id)
@@ -225,7 +225,7 @@ def create_router(ctx: WebUIContext) -> APIRouter:
     async def api_update_rolemenu(
         request: Request, server_id: str, menu_id: str, body: RoleMenuUpdate
     ):
-        ctx.require_admin(request)
+        ctx.require_guild_admin(request, server_id)
 
         async def _update():
             repo = ReactionRolesRepository(server_id)
@@ -285,7 +285,7 @@ def create_router(ctx: WebUIContext) -> APIRouter:
 
     @router.delete("/api/servers/{server_id}/rolemenus/{menu_id}")
     async def api_delete_rolemenu(request: Request, server_id: str, menu_id: str):
-        ctx.require_admin(request)
+        ctx.require_guild_admin(request, server_id)
 
         async def _delete():
             repo = ReactionRolesRepository(server_id)

--- a/src/webui/routes/servers.py
+++ b/src/webui/routes/servers.py
@@ -58,7 +58,7 @@ def create_router(ctx: WebUIContext) -> APIRouter:
 
     @router.get("/api/servers")
     async def api_get_servers(request: Request):
-        """Get servers where both the user and the bot are present."""
+        """Get servers the user manages (developers see every configured server)."""
         session = ctx.require_admin(request)
         data = ctx.get_full_config()
         servers = data.get("servers", {})
@@ -67,14 +67,18 @@ def create_router(ctx: WebUIContext) -> APIRouter:
         if ctx.bot and ctx.bot.guilds:
             bot_guild_ids = {str(g.id) for g in ctx.bot.guilds}
 
-        user_guilds = {g["id"]: g for g in session.guilds}
+        is_developer = ctx.oauth.is_developer(session)
+        managed_guilds = {g["id"]: g for g in ctx.oauth.get_user_managed_guilds(session)}
         result: dict = {}
 
-        # Servers already in config — only if bot is in them
+        # Servers already in config — only if bot is in them and the user
+        # manages them (a guild admin must not see other guilds' config).
         for server_id, server_config in servers.items():
             if bot_guild_ids and str(server_id) not in bot_guild_ids:
                 continue
-            guild_info = user_guilds.get(str(server_id), {})
+            if not is_developer and str(server_id) not in managed_guilds:
+                continue
+            guild_info = managed_guilds.get(str(server_id), {})
             result[server_id] = {
                 "name": guild_info.get(
                     "name", server_config.get("serverName", f"Serveur {server_id}")
@@ -83,8 +87,8 @@ def create_router(ctx: WebUIContext) -> APIRouter:
                 "config": server_config,
             }
 
-        # User's managed guilds not yet in config — only if bot is in them
-        for guild_id, guild_info in user_guilds.items():
+        # Managed guilds not yet in config — only if bot is in them
+        for guild_id, guild_info in managed_guilds.items():
             if guild_id not in result and (not bot_guild_ids or guild_id in bot_guild_ids):
                 result[guild_id] = {
                     "name": guild_info.get("name", f"Serveur {guild_id}"),
@@ -97,7 +101,7 @@ def create_router(ctx: WebUIContext) -> APIRouter:
     @router.get("/api/servers/{server_id}/channels")
     async def api_get_server_channels(request: Request, server_id: str):
         """List text/news channels for the given server (for channel-picker dropdowns)."""
-        ctx.require_admin(request)
+        ctx.require_guild_admin(request, server_id)
         bot_loop = ctx.require_bot_loop()
 
         async def _fetch():
@@ -202,7 +206,7 @@ def create_router(ctx: WebUIContext) -> APIRouter:
         Pulls from the ``users`` MongoDB collection maintained by userinfoext;
         falls back to the live guild member cache if the collection is empty.
         """
-        ctx.require_admin(request)
+        ctx.require_guild_admin(request, server_id)
         bot_loop = ctx.require_bot_loop()
 
         async def _fetch():
@@ -277,7 +281,7 @@ def create_router(ctx: WebUIContext) -> APIRouter:
     @router.get("/api/servers/{server_id}")
     async def api_get_server(request: Request, server_id: str):
         """Get configuration for a specific server."""
-        ctx.require_admin(request)
+        ctx.require_guild_admin(request, server_id)
         data = ctx.get_full_config()
         server_config = data.get("servers", {}).get(server_id)
         if server_config is None:
@@ -289,7 +293,7 @@ def create_router(ctx: WebUIContext) -> APIRouter:
         request: Request, server_id: str, module_name: str, body: ConfigUpdate
     ):
         """Update a specific module's config for a server."""
-        ctx.require_admin(request)
+        ctx.require_guild_admin(request, server_id)
         data = ctx.get_full_config()
 
         if server_id not in data.get("servers", {}):
@@ -306,7 +310,7 @@ def create_router(ctx: WebUIContext) -> APIRouter:
         request: Request, server_id: str, module_name: str, body: ModuleToggle
     ):
         """Enable or disable a module for a server."""
-        ctx.require_admin(request)
+        ctx.require_guild_admin(request, server_id)
         data = ctx.get_full_config()
 
         if server_id not in data.get("servers", {}):
@@ -328,7 +332,7 @@ def create_router(ctx: WebUIContext) -> APIRouter:
     @router.post("/api/servers/{server_id}/modules/moduleEmbedManager/publish")
     async def api_embedmanager_publish(request: Request, server_id: str):
         """Publish configured embeds to the target Discord message."""
-        ctx.require_admin(request)
+        ctx.require_guild_admin(request, server_id)
         bot_loop = ctx.require_bot_loop()
 
         _, module_config, enabled_servers = bot_load_config("moduleEmbedManager")

--- a/src/webui/routes/spotify.py
+++ b/src/webui/routes/spotify.py
@@ -55,7 +55,7 @@ def create_router(ctx: WebUIContext) -> APIRouter:
     @router.get("/api/spotify/status")
     async def api_spotify_status(request: Request):
         """Report whether the Spotify token cache is populated and valid."""
-        ctx.require_admin(request)
+        ctx.require_developer(request)
         status = get_token_status()
         status["callback_url"] = _callback_url()
         if status.get("authorized"):
@@ -65,7 +65,7 @@ def create_router(ctx: WebUIContext) -> APIRouter:
     @router.get("/spotify/auth/start")
     async def spotify_auth_start(request: Request):
         """Begin Spotify OAuth: redirect the admin to Spotify's authorize page."""
-        ctx.require_admin(request)
+        ctx.require_developer(request)
         redirect_uri = _callback_url()
         if not redirect_uri.endswith(CALLBACK_PATH) or redirect_uri == CALLBACK_PATH:
             raise HTTPException(
@@ -104,7 +104,7 @@ def create_router(ctx: WebUIContext) -> APIRouter:
         error: str = "",
     ):
         """Receive Spotify's redirect and exchange the code for a token."""
-        ctx.require_admin(request)
+        ctx.require_developer(request)
 
         if error:
             return _result_page(ok=False, message=f"Spotify a refusé l'autorisation : {error}")

--- a/src/webui/static/index.html
+++ b/src/webui/static/index.html
@@ -2681,8 +2681,8 @@
     // ── Navigation ────────────────────────────────────
     function navigate(page, serverId = null, moduleName = null) {
         // Restrict admin-only pages for non-admin users
-        const adminPages = ['global', 'server', 'module'];
-        const developerPages = ['extensions', 'logs'];
+        const adminPages = ['server', 'module'];
+        const developerPages = ['global', 'extensions', 'logs'];
         if (adminPages.includes(page) && !isAdmin()) {
             page = 'home';
             serverId = null;
@@ -4809,18 +4809,16 @@
                         <div class="nav-item ${state.currentPage === 'home' ? 'active' : ''}" onclick="navigate('home')">
                             <span class="icon">🏠</span> Accueil
                         </div>
-                        ${isAdmin() ? `
+                        ${isDeveloper() ? `
                         <div class="nav-item ${state.currentPage === 'global' ? 'active' : ''}" onclick="navigate('global')">
                             <span class="icon">⚙️</span> Config globale
                         </div>
-                        ${isDeveloper() ? `
                         <div class="nav-item ${state.currentPage === 'extensions' ? 'active' : ''}" onclick="navigate('extensions')">
                             <span class="icon">🧩</span> Extensions
                         </div>
                         <div class="nav-item ${state.currentPage === 'logs' ? 'active' : ''}" onclick="navigate('logs')">
                             <span class="icon">📋</span> Logs
                         </div>
-                        ` : ''}
                         ` : ''}
                     </div>
                     ${isAdmin() ? `
@@ -4960,7 +4958,7 @@
 
         // ── Quick Actions ──────────────────────────────
         const loadedExts = (state.extensions || []).filter(e => e.loaded).length;
-        const quickActionsHtml = `
+        const quickActionsHtml = !isDeveloper() ? '' : `
             <div class="section-label">Actions rapides</div>
             <div class="quick-actions-grid">
                 <button class="quick-action-btn" onclick="navigate('global')">
@@ -4968,7 +4966,6 @@
                     <span class="quick-action-label">Config globale</span>
                     <span class="quick-action-sub">Tokens, APIs…</span>
                 </button>
-                ${isDeveloper() ? `
                 <button class="quick-action-btn" onclick="navigate('extensions')">
                     <span class="quick-action-icon">🧩</span>
                     <span class="quick-action-label">Extensions</span>
@@ -4984,7 +4981,6 @@
                     <span class="quick-action-label">Logs</span>
                     <span class="quick-action-sub">Temps réel</span>
                 </button>
-                ` : ''}
                 <button class="quick-action-btn" onclick="downloadConfig()">
                     <span class="quick-action-icon">⬇️</span>
                     <span class="quick-action-label">Exporter</span>
@@ -5560,7 +5556,7 @@
             toast(`${moduleName} ${enabled ? 'activé' : 'désactivé'}${reloadSuffix}`,
                 result?.reload?.error ? 'warning' : 'success');
             await loadServers();
-            await loadConfig();
+            if (isDeveloper()) await loadConfig();
             render();
         } catch (e) { /* handled by api() */ }
     }
@@ -5869,7 +5865,7 @@
                 toast(`Configuration sauvegardée, rechargement échoué : ${result.reload.error}`, 'warning');
             }
             await loadServers();
-            await loadConfig();
+            if (isDeveloper()) await loadConfig();
             render();
         } catch (e) { /* handled by api() */ }
     }
@@ -6197,7 +6193,7 @@
                 toast(`Configuration sauvegardée, rechargement échoué : ${result.reload.error}`, 'warning');
             }
             await loadServers();
-            await loadConfig();
+            if (isDeveloper()) await loadConfig();
             render();
         });
     }
@@ -6281,7 +6277,10 @@
         if (state.user) {
             const promises = [loadBotInfo()];
             if (isAdmin()) {
-                promises.push(loadServers(), loadModules(), loadSchemas(), loadConfig(), loadLogs(), loadExtensions());
+                promises.push(loadServers(), loadModules(), loadSchemas());
+            }
+            if (isDeveloper()) {
+                promises.push(loadConfig(), loadLogs(), loadExtensions());
             }
             await Promise.all(promises);
         }
@@ -6291,7 +6290,7 @@
         if (hashParams.get('spotify_auth')) {
             const ok = hashParams.get('spotify_auth') === 'ok';
             toast(hashParams.get('msg') || (ok ? 'Spotify connecté' : 'Échec Spotify'), ok ? 'success' : 'error');
-            if (isAdmin()) {
+            if (isDeveloper()) {
                 await loadSpotifyAuth();
                 navigate('global');
             }

--- a/tests/test_webui_auth.py
+++ b/tests/test_webui_auth.py
@@ -169,6 +169,74 @@ def test_callback_accepts_matching_state():
     assert "michel_session=" in set_cookie
 
 
+# ── Per-guild authorization ─────────────────────────────────────────────
+
+
+def make_authed_request(session_token: str | None) -> Request:
+    headers = []
+    if session_token is not None:
+        headers.append((b"cookie", f"michel_session={session_token}".encode()))
+    return Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "scheme": "http",
+            "path": "/api/servers/1",
+            "query_string": b"",
+            "headers": headers,
+        }
+    )
+
+
+def test_user_manages_guild_checks_that_specific_guild():
+    oauth = make_oauth()
+    ctx = WebUIContext(bot=None, bot_loop=None, oauth=oauth)
+    session = make_session(
+        guilds=[
+            {"id": "1", "permissions": "32"},  # MANAGE_GUILD
+            {"id": "2", "permissions": "8"},  # ADMINISTRATOR
+            {"id": "3", "owner": True, "permissions": "0"},
+            {"id": "4", "permissions": "0"},  # plain member
+        ]
+    )
+    assert ctx.user_manages_guild(session, "1")
+    assert ctx.user_manages_guild(session, 2)  # int ids accepted
+    assert ctx.user_manages_guild(session, "3")
+    assert not ctx.user_manages_guild(session, "4")
+    assert not ctx.user_manages_guild(session, "999")  # not even a member
+
+
+def test_developer_bypasses_guild_check():
+    oauth = make_oauth(developer_user_ids=["42"])
+    ctx = WebUIContext(bot=None, bot_loop=None, oauth=oauth)
+    session = make_session(guilds=[])
+    assert ctx.user_manages_guild(session, "999")
+    assert ctx.is_admin_user(session)  # developer is admin even with no bot
+
+
+def test_require_guild_admin_enforces_per_guild_access():
+    from fastapi import HTTPException
+
+    oauth = make_oauth()
+    ctx = WebUIContext(bot=None, bot_loop=None, oauth=oauth)
+    session = make_session(guilds=[{"id": "1", "permissions": "32"}])
+    oauth.sessions[session.session_token] = session
+
+    # No session cookie → 401
+    with pytest.raises(HTTPException) as exc:
+        ctx.require_guild_admin(make_authed_request(None), "1")
+    assert exc.value.status_code == 401
+
+    # Managing guild 1 grants nothing on guild 2 → 403
+    with pytest.raises(HTTPException) as exc:
+        ctx.require_guild_admin(make_authed_request(session.session_token), "2")
+    assert exc.value.status_code == 403
+
+    # The managed guild itself is allowed
+    granted = ctx.require_guild_admin(make_authed_request(session.session_token), "1")
+    assert granted is session
+
+
 # ── Persistence glue (stubbed repository) ───────────────────────────────
 
 


### PR DESCRIPTION
## Per-guild authorization (follow-up promised in #60)

Until now, `require_admin` passed for anyone with MANAGE_GUILD/ADMINISTRATOR on **any one** guild the bot is in — which granted read/write on **every** guild's config, member lists, infractions (including revoking cases) and role menus. `GET /api/config` and `/api/global-config` also exposed the bot token, MongoDB URL and every API secret at that same level, and the PUT let any guild admin rewrite them.

### Backend

- **`require_guild_admin(request, server_id)`** in `WebUIContext`: the user must own, administer or manage *that specific guild* (per the OAuth guild list), with a developer bypass. Applied to every `/api/servers/{server_id}/…` route — servers (channels, members, get, module save/toggle, embed publish), moderation (list + revoke), and rolemenus (all five).
- **`GET /api/servers`** now only lists guilds the user manages; developers see every configured server. Previously it returned every configured guild's full config to any admin — including guilds the user wasn't even a member of.
- **Developer-only**: `/api/config`, `/api/global-config` (GET/PUT), `/api/cleanup-config` (they carry/mutate global secrets), and the Spotify OAuth routes (they rebind the bot's own Spotify account).
- `is_admin_user()` returns True for developers regardless of guild membership, so the developer allowlist works even from outside the guilds.
- Module/global **schemas** (`/api/modules`, `/api/schemas/*`) stay at admin level — metadata only, needed by the per-server editor.

### Frontend

The "Config globale" page, its quick actions (export / cleanup), and the `loadConfig`/`loadLogs`/`loadExtensions` fetches are now gated on `is_developer`; per-server pages keep working exactly as before for guild admins. SPA script syntax verified with `node --check`.

### Impact on you

None expected: as the developer (`webui.developerUserIds`) you keep seeing everything. Other dashboard users now only see and edit the guilds they actually manage, and no longer have access to the global config page.

## Checks

`ruff check` / `ruff format --check` ✅ · `mypy src` ✅ · `pytest` 66 passed (3 new) · `node --check` on the SPA ✅

https://claude.ai/code/session_013YC9RjMQVzzuyq3S3BzVYT

---
_Generated by [Claude Code](https://claude.ai/code/session_013YC9RjMQVzzuyq3S3BzVYT)_