### PR TITLE
webui: real server names for developers + guild ids in the sidebar

### DIFF
--- a/src/webui/routes/servers.py
+++ b/src/webui/routes/servers.py
@@ -58,17 +58,33 @@ def create_router(ctx: WebUIContext) -> APIRouter:
 
     @router.get("/api/servers")
     async def api_get_servers(request: Request):
-        """Get servers the user manages (developers see every configured server)."""
+        """Get servers the user manages (developers see every bot guild)."""
         session = ctx.require_admin(request)
         data = ctx.get_full_config()
         servers = data.get("servers", {})
 
-        bot_guild_ids: set[str] = set()
+        # Bot guild cache: authoritative names/icons even for guilds the
+        # user doesn't manage (OAuth only describes the user's own guilds).
+        bot_guilds: dict[str, object] = {}
         if ctx.bot and ctx.bot.guilds:
-            bot_guild_ids = {str(g.id) for g in ctx.bot.guilds}
+            bot_guilds = {str(g.id): g for g in ctx.bot.guilds}
+        bot_guild_ids = set(bot_guilds)
 
         is_developer = ctx.oauth.is_developer(session)
         managed_guilds = {g["id"]: g for g in ctx.oauth.get_user_managed_guilds(session)}
+
+        def server_entry(server_id: str, server_config: dict) -> dict:
+            guild_info = managed_guilds.get(server_id, {})
+            bot_guild = bot_guilds.get(server_id)
+            name = (
+                guild_info.get("name")
+                or getattr(bot_guild, "name", None)
+                or server_config.get("serverName")
+                or f"Serveur {server_id}"
+            )
+            icon = guild_info.get("icon") or getattr(getattr(bot_guild, "icon", None), "hash", None)
+            return {"name": name, "icon": icon, "config": server_config}
+
         result: dict = {}
 
         # Servers already in config — only if bot is in them and the user
@@ -78,23 +94,16 @@ def create_router(ctx: WebUIContext) -> APIRouter:
                 continue
             if not is_developer and str(server_id) not in managed_guilds:
                 continue
-            guild_info = managed_guilds.get(str(server_id), {})
-            result[server_id] = {
-                "name": guild_info.get(
-                    "name", server_config.get("serverName", f"Serveur {server_id}")
-                ),
-                "icon": guild_info.get("icon"),
-                "config": server_config,
-            }
+            result[server_id] = server_entry(str(server_id), server_config)
 
-        # Managed guilds not yet in config — only if bot is in them
-        for guild_id, guild_info in managed_guilds.items():
+        # Guilds not yet in config — the user's managed guilds, plus every
+        # bot guild for developers. Only if the bot is in them.
+        candidate_ids = set(managed_guilds)
+        if is_developer:
+            candidate_ids |= bot_guild_ids
+        for guild_id in candidate_ids:
             if guild_id not in result and (not bot_guild_ids or guild_id in bot_guild_ids):
-                result[guild_id] = {
-                    "name": guild_info.get("name", f"Serveur {guild_id}"),
-                    "icon": guild_info.get("icon"),
-                    "config": {},
-                }
+                result[guild_id] = server_entry(guild_id, {})
 
         return JSONResponse(result)
 

--- a/src/webui/static/index.html
+++ b/src/webui/static/index.html
@@ -171,6 +171,25 @@
             color: white;
         }
 
+        .nav-item-label {
+            display: flex;
+            flex-direction: column;
+            min-width: 0;
+            line-height: 1.25;
+        }
+        .nav-item-name {
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+        .nav-item-sub {
+            font-size: 10px;
+            color: var(--text-muted);
+            font-family: var(--font-mono, monospace);
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
         .nav-item .icon {
             font-size: 18px;
             width: 24px;
@@ -4775,7 +4794,10 @@
                         <div class="server-icon">
                             ${iconUrl ? `<img src="${iconUrl}" alt="">` : s.name?.charAt(0) || '?'}
                         </div>
-                        <span>${s.name || id}</span>
+                        <div class="nav-item-label">
+                            <span class="nav-item-name">${s.name || id}</span>
+                            <span class="nav-item-sub">${id}</span>
+                        </div>
                     </div>
                 `;
             }).join('')

--- a/tests/test_webui_auth.py
+++ b/tests/test_webui_auth.py
@@ -112,6 +112,50 @@ def test_http_client_one_session_per_loop():
     assert a is not b
 
 
+# ── /api/servers listing ────────────────────────────────────────────────
+
+
+def test_server_list_scoping_and_bot_cache_names():
+    """Developers see every bot guild with cache-resolved names; admins only theirs."""
+    import json
+    from types import SimpleNamespace
+
+    import src.webui.routes.servers as servers_routes
+
+    oauth = make_oauth(developer_user_ids=["42"])
+    bot = SimpleNamespace(
+        guilds=[
+            SimpleNamespace(id=1, name="Coloc", icon=SimpleNamespace(hash="abc123")),
+            SimpleNamespace(id=2, name="Autre serveur", icon=None),
+        ]
+    )
+    ctx = WebUIContext(bot=bot, bot_loop=None, oauth=oauth)
+    # Guild 99 is configured but the bot left it — must never be listed.
+    ctx.get_full_config = lambda: {"servers": {"1": {"moduleXp": {}}, "99": {}}}
+    router = servers_routes.create_router(ctx)
+    endpoint = next(r for r in router.routes if r.path == "/api/servers").endpoint
+
+    def call(session):
+        oauth.sessions[session.session_token] = session
+        request = SimpleNamespace(cookies={"michel_session": session.session_token})
+        return json.loads(asyncio.run(endpoint(request)).body)
+
+    # Developer managing nothing: both bot guilds, names/icons from the cache
+    dev = make_session(user_id="42", guilds=[])
+    out = call(dev)
+    assert set(out) == {"1", "2"}
+    assert out["1"]["name"] == "Coloc" and out["1"]["icon"] == "abc123"
+    assert out["2"]["name"] == "Autre serveur" and out["2"]["config"] == {}
+
+    # Plain admin managing guild 1: only guild 1, OAuth name takes precedence
+    admin = make_session(
+        user_id="7", guilds=[{"id": "1", "name": "Coloc (oauth)", "permissions": "32"}]
+    )
+    out = call(admin)
+    assert set(out) == {"1"}
+    assert out["1"]["name"] == "Coloc (oauth)"
+
+
 # ── Callback state (CSRF) validation ────────────────────────────────────
 #
 # The route endpoint is invoked directly with a hand-built starlette Request


### PR DESCRIPTION
Two dashboard quality-of-life changes for the developer view:

### Real names for unmanaged guilds

`/api/servers` resolved names from the user's OAuth guild list only, so since #61 a developer looking at guilds they don't manage saw `Serveur 123456789…`. Names and icons now fall back to the **bot's guild cache** (`name` + `icon.hash` — the SPA already builds icon URLs from a hash, so no frontend change). Developers are also offered **every guild the bot is in**, not just the configured ones, so a freshly invited guild can be set up from the dashboard before any config exists.

Plain admins are unchanged: they still see only the guilds they manage, with OAuth data taking precedence when present. Configured guilds the bot has left remain hidden for everyone. Covered by a stub-based endpoint test (developer vs. admin views).

### Guild id under each server name

The sidebar's server entries now show the guild id in small muted monospace under the name — handy for cross-referencing `config.json`, Mongo databases (`guild_{id}`) and log lines.

## Checks

`ruff` ✅ · `mypy src` ✅ · `pytest` 73 passed (1 new) · `node --check` on the SPA ✅

https://claude.ai/code/session_013YC9RjMQVzzuyq3S3BzVYT

---
_Generated by [Claude Code](https://claude.ai/code/session_013YC9RjMQVzzuyq3S3BzVYT)_