### PR TITLE
feat(webui): harden the dashboard — secret masking, auth rate limit, atomic config writes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,12 @@ When schema-driven forms aren't enough (e.g. CRUD over a list of objects, anythi
 
 ### Web UI authorization
 
-Two tiers, enforced via helpers on `WebUIContext` (`src/webui/context.py`): any authenticated Discord user can manage the guilds where they hold `MANAGE_GUILD`/`ADMINISTRATOR` (or ownership); user IDs in `config.webui.developerUserIds` additionally get global config, extension reload, and the live log stream. Sessions are MongoDB-persisted with a TTL index (`src/webui/sessions.py`). Use `require_guild_admin()` for per-guild routes and `require_developer()` for global ones — never skip the check.
+Two tiers, enforced via helpers on `WebUIContext` (`src/webui/context.py`): any authenticated Discord user can manage the guilds where they hold `MANAGE_GUILD`/`ADMINISTRATOR` (or ownership); user IDs in `config.webui.developerUserIds` additionally get global config, extension reload, and the live log stream. Sessions are MongoDB-persisted with a TTL index (`src/webui/sessions.py`). Use `require_guild_admin()` for per-guild routes and `require_developer()` for global ones — never skip the check. The auth endpoints are rate-limited per client IP (`src/webui/ratelimit.py`).
+
+### Web UI config I/O rules
+
+- **Mutations**: use `ctx.mutate_config(mutator)` — an atomic read-modify-write under the config write lock — never `get_full_config()` + `save_config()` in sequence (that pattern silently drops concurrent edits). Include the acting user (`session.username`/`session.user_id` from the `require_*` helper) in the mutation log line.
+- **Secrets**: schema fields declared `secret=True` are masked to a placeholder in every API response (`src/webui/secrets.py`); the save paths call `restore_section()` so an untouched placeholder keeps the on-disk value. Any new endpoint that returns config must mask (`mask_full_config` / `mask_section` / `mask_server_config`), and any new save path for schema-backed config must restore.
 
 ### Per-guild data isolation
 

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -150,6 +150,31 @@ class ConfigStore:
             _atomic_write(data)
         self._update_and_notify(data)
 
+    def mutate(self, mutator: Callable[[dict[str, Any]], None]) -> dict[str, Any]:
+        """Atomically read-modify-write the config under the write lock.
+
+        ``mutator`` receives a fresh read of the on-disk config and edits it in
+        place. Holding ``_write_lock`` across read → mutate → write closes the
+        race where two concurrent "load full config, edit, save" sequences
+        (e.g. two dashboard requests) silently drop one of the edits.
+
+        Raises :class:`src.core.errors.ConfigError` instead of writing when the
+        config file is unreadable or empty — mutating an empty skeleton would
+        wipe the real config.
+        """
+        from src.core.errors import ConfigError
+
+        with _write_lock:
+            data = _load_config_file()
+            if not data:
+                raise ConfigError(
+                    f"{CONFIG_PATH} unreadable or empty — refusing to mutate and overwrite it"
+                )
+            mutator(data)
+            _atomic_write(data)
+        self._update_and_notify(data)
+        return data
+
     def reload(self) -> dict[str, Any]:
         """Re-read ``config/config.json`` from disk and notify subscribers."""
         data = _load_config_file()

--- a/src/webui/context.py
+++ b/src/webui/context.py
@@ -77,14 +77,44 @@ class WebUIContext:
         try:
             config_store.save_full(data)
         except Exception as e:
-            logger.exception("Config save failed")
-            detail = f"Échec d'écriture de config/config.json : {e}"
-            if isinstance(e, PermissionError):
-                detail += (
-                    " — le dossier config/ n'est pas inscriptible par l'utilisateur du "
-                    "conteneur (uid 1000). Sur l'hôte : chown -R 1000:1000 ./config"
-                )
-            raise HTTPException(status_code=500, detail=detail) from e
+            self._raise_save_error(e)
+
+    def mutate_config(self, mutator) -> dict:
+        """Read-modify-write the config atomically (see ``ConfigStore.mutate``).
+
+        Prefer this over ``get_full_config()`` + ``save_config()`` in routes:
+        the mutator runs against a fresh read under the write lock, so a
+        concurrent save can't be silently overwritten.
+        """
+        from src.core.config import config_store
+        from src.core.errors import ConfigError
+
+        try:
+            return config_store.mutate(mutator)
+        except ConfigError as e:
+            raise HTTPException(
+                status_code=503,
+                detail=(
+                    "config/config.json illisible ou vide — "
+                    "modification refusée pour ne pas écraser la configuration."
+                ),
+            ) from e
+        except HTTPException:
+            raise
+        except Exception as e:
+            self._raise_save_error(e)
+            raise  # unreachable — _raise_save_error always raises
+
+    @staticmethod
+    def _raise_save_error(e: Exception) -> None:
+        logger.exception("Config save failed")
+        detail = f"Échec d'écriture de config/config.json : {e}"
+        if isinstance(e, PermissionError):
+            detail += (
+                " — le dossier config/ n'est pas inscriptible par l'utilisateur du "
+                "conteneur (uid 1000). Sur l'hôte : chown -R 1000:1000 ./config"
+            )
+        raise HTTPException(status_code=500, detail=detail) from e
 
     # --- Session / authorization -------------------------------------
 

--- a/src/webui/ratelimit.py
+++ b/src/webui/ratelimit.py
@@ -1,0 +1,55 @@
+"""Tiny in-memory sliding-window rate limiter for auth endpoints.
+
+The dashboard binds to loopback behind a reverse proxy, so the client key
+honors the leftmost ``X-Forwarded-For`` entry when present and falls back to
+the socket peer. State is process-local (one uvicorn worker), which is exactly
+the deployment shape of the Web UI.
+"""
+
+import time
+from collections import deque
+
+from fastapi import Request
+
+
+class RateLimiter:
+    """Allow at most *max_requests* per *window_seconds* for each key."""
+
+    def __init__(self, max_requests: int, window_seconds: float) -> None:
+        self.max_requests = max_requests
+        self.window_seconds = window_seconds
+        self._hits: dict[str, deque[float]] = {}
+
+    def check(self, key: str) -> float:
+        """Record a hit for *key*; return 0 if allowed, else seconds to wait.
+
+        Refused attempts are not recorded, so a client that backs off for the
+        advertised delay is let through again.
+        """
+        now = time.monotonic()
+        hits = self._hits.get(key)
+        if hits is None:
+            hits = self._hits[key] = deque()
+        cutoff = now - self.window_seconds
+        while hits and hits[0] <= cutoff:
+            hits.popleft()
+        if len(hits) >= self.max_requests:
+            return max(hits[0] + self.window_seconds - now, 0.0) or 1.0
+        hits.append(now)
+        self._prune(cutoff)
+        return 0.0
+
+    def _prune(self, cutoff: float) -> None:
+        """Drop keys whose hits have all aged out, so the dict stays bounded."""
+        for key in [k for k, v in self._hits.items() if not v or v[-1] <= cutoff]:
+            del self._hits[key]
+
+
+def client_ip(request: Request) -> str:
+    """Client key for rate limiting (leftmost X-Forwarded-For, else socket peer)."""
+    forwarded = request.headers.get("x-forwarded-for", "")
+    if forwarded:
+        first = forwarded.split(",")[0].strip()
+        if first:
+            return first
+    return request.client.host if request.client else "unknown"

--- a/src/webui/routes/auth.py
+++ b/src/webui/routes/auth.py
@@ -5,7 +5,16 @@ import secrets
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 
+from src.core import logging as logutil
 from src.webui.context import COOKIE_NAME, WebUIContext
+from src.webui.ratelimit import RateLimiter, client_ip
+
+logger = logutil.init_logger("webui.routes.auth")
+
+# Per-IP budget shared by /auth/login and /auth/callback — generous for a
+# human retrying a login, tight enough to throttle brute-forcing the flow.
+AUTH_RATE_LIMIT = 10
+AUTH_RATE_WINDOW_SECONDS = 60.0
 
 
 def _is_https(request: Request) -> bool:
@@ -18,10 +27,22 @@ def _is_https(request: Request) -> bool:
 
 def create_router(ctx: WebUIContext) -> APIRouter:
     router = APIRouter()
+    auth_limiter = RateLimiter(AUTH_RATE_LIMIT, AUTH_RATE_WINDOW_SECONDS)
+
+    def _throttle(request: Request) -> None:
+        retry_after = auth_limiter.check(client_ip(request))
+        if retry_after:
+            logger.warning("Auth rate limit hit for %s", client_ip(request))
+            raise HTTPException(
+                status_code=429,
+                detail="Trop de tentatives de connexion — réessaie dans un instant.",
+                headers={"Retry-After": str(int(retry_after) + 1)},
+            )
 
     @router.get("/auth/login")
     async def auth_login(request: Request):
         """Redirect to Discord OAuth2 login."""
+        _throttle(request)
         state = secrets.token_urlsafe(16)
         url = ctx.oauth.get_oauth_url(state)
         response = RedirectResponse(url=url)
@@ -38,6 +59,7 @@ def create_router(ctx: WebUIContext) -> APIRouter:
     @router.get("/auth/callback")
     async def auth_callback(request: Request, code: str = "", state: str = ""):
         """Handle Discord OAuth2 callback."""
+        _throttle(request)
         if not code:
             raise HTTPException(status_code=400, detail="Code manquant")
 

--- a/src/webui/routes/config.py
+++ b/src/webui/routes/config.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel
 from src.core import logging as logutil
 from src.webui.context import WebUIContext, discover_modules
 from src.webui.schemas import GLOBAL_CONFIG_SCHEMAS, MODULE_SCHEMAS
+from src.webui.secrets import mask_full_config, mask_section, restore_section
 
 logger = logutil.init_logger("webui.routes.config")
 
@@ -21,10 +22,10 @@ def create_router(ctx: WebUIContext) -> APIRouter:
 
     @router.get("/api/config")
     async def api_get_config(request: Request):
-        """Get the full configuration (contains secrets — developer only)."""
+        """Get the full configuration, secrets masked (developer only)."""
         ctx.require_developer(request)
         data = ctx.get_full_config()
-        return JSONResponse(data)
+        return JSONResponse(mask_full_config(data))
 
     @router.get("/api/modules")
     async def api_get_modules(request: Request):
@@ -65,32 +66,41 @@ def create_router(ctx: WebUIContext) -> APIRouter:
 
     @router.get("/api/global-config")
     async def api_get_global_config(request: Request):
-        """Get global configuration (contains secrets — developer only)."""
+        """Get global configuration, secrets masked (developer only)."""
         ctx.require_developer(request)
         data = ctx.get_full_config()
-        return JSONResponse(data.get("config", {}))
+        global_config = data.get("config", {})
+        masked = {
+            section: mask_section(section_data, GLOBAL_CONFIG_SCHEMAS.get(section))
+            for section, section_data in global_config.items()
+        }
+        return JSONResponse(masked)
 
     @router.put("/api/global-config/{section}")
     async def api_update_global_config(request: Request, section: str, body: GlobalConfigUpdate):
-        """Update a section of the global configuration (developer only)."""
-        ctx.require_developer(request)
-        data = ctx.get_full_config()
-        data.setdefault("config", {})[section] = body.config
-        ctx.save_config(data)
-        logger.info(f"Updated global config section: {section}")
+        """Update a section of the global configuration (developer only).
+
+        Secret fields submitted as the untouched mask placeholder keep their
+        current on-disk value (the dashboard never sees real secrets).
+        """
+        session = ctx.require_developer(request)
+        schema = GLOBAL_CONFIG_SCHEMAS.get(section)
+
+        def mutator(data: dict) -> None:
+            current = data.get("config", {}).get(section)
+            data.setdefault("config", {})[section] = restore_section(body.config, current, schema)
+
+        ctx.mutate_config(mutator)
+        logger.info(
+            "Updated global config section %s (by %s/%s)",
+            section,
+            session.username,
+            session.user_id,
+        )
         return JSONResponse({"status": "ok"})
 
-    @router.post("/api/cleanup-config")
-    async def api_cleanup_config(request: Request, dry_run: bool = False):
-        """Remove config keys not present in the schemas.
-
-        Query params:
-            dry_run: if true, return what would be removed without saving.
-        """
-        ctx.require_developer(request)
-        data = ctx.get_full_config()
-        removed: list[dict] = []
-
+    def _strip_unknown_keys(data: dict, removed: list[dict], apply: bool) -> None:
+        """Collect (and optionally delete) config keys absent from the schemas."""
         # Clean up per-server module configs
         servers = data.get("servers", {})
         for server_id, server_config in servers.items():
@@ -115,7 +125,7 @@ def create_router(ctx: WebUIContext) -> APIRouter:
                                 "value": module_config[key],
                             }
                         )
-                        if not dry_run:
+                        if apply:
                             del module_config[key]
 
         # Clean up global config sections
@@ -136,12 +146,32 @@ def create_router(ctx: WebUIContext) -> APIRouter:
                             "value": section_data[key],
                         }
                     )
-                    if not dry_run:
+                    if apply:
                         del section_data[key]
 
+    @router.post("/api/cleanup-config")
+    async def api_cleanup_config(request: Request, dry_run: bool = False):
+        """Remove config keys not present in the schemas.
+
+        Query params:
+            dry_run: if true, return what would be removed without saving.
+        """
+        session = ctx.require_developer(request)
+        removed: list[dict] = []
+
+        # Probe on a plain read first; only take the write path when there is
+        # something to delete, so a no-op cleanup never rewrites the file.
+        _strip_unknown_keys(ctx.get_full_config(), removed, apply=False)
+
         if not dry_run and removed:
-            ctx.save_config(data)
-            logger.info("Config cleanup: removed %d key(s)", len(removed))
+            removed = []
+            ctx.mutate_config(lambda data: _strip_unknown_keys(data, removed, apply=True))
+            logger.info(
+                "Config cleanup: removed %d key(s) (by %s/%s)",
+                len(removed),
+                session.username,
+                session.user_id,
+            )
 
         # Sanitise values for JSON response (avoid huge blobs)
         for entry in removed:

--- a/src/webui/routes/extensions.py
+++ b/src/webui/routes/extensions.py
@@ -92,11 +92,19 @@ def create_router(ctx: WebUIContext) -> APIRouter:
     @router.post("/api/extensions/{ext_name:path}/toggle")
     async def api_toggle_extension(request: Request, ext_name: str, body: ExtensionToggle):
         """Enable or disable an extension globally (updates config and loads/unloads)."""
-        ctx.require_developer(request)
-        data = ctx.get_full_config()
-        data.setdefault("config", {}).setdefault("extensions", {})[ext_name] = body.enabled
-        ctx.save_config(data)
-        logger.info(f"{'Enabled' if body.enabled else 'Disabled'} extension {ext_name} in config")
+        session = ctx.require_developer(request)
+
+        def mutator(data: dict) -> None:
+            data.setdefault("config", {}).setdefault("extensions", {})[ext_name] = body.enabled
+
+        ctx.mutate_config(mutator)
+        logger.info(
+            "%s extension %s in config (by %s/%s)",
+            "Enabled" if body.enabled else "Disabled",
+            ext_name,
+            session.username,
+            session.user_id,
+        )
 
         loaded = ext_name in set(ctx.get_extension_module_paths()) if ctx.bot else False
         error = None

--- a/src/webui/routes/servers.py
+++ b/src/webui/routes/servers.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel
 from src.core import logging as logutil
 from src.core.config import load_config as bot_load_config
 from src.webui.context import WebUIContext, build_module_to_extension_map
+from src.webui.secrets import mask_server_config, restore_section
 
 logger = logutil.init_logger("webui.routes.servers")
 
@@ -83,7 +84,7 @@ def create_router(ctx: WebUIContext) -> APIRouter:
                 or f"Serveur {server_id}"
             )
             icon = guild_info.get("icon") or getattr(getattr(bot_guild, "icon", None), "hash", None)
-            return {"name": name, "icon": icon, "config": server_config}
+            return {"name": name, "icon": icon, "config": mask_server_config(server_config)}
 
         result: dict = {}
 
@@ -289,28 +290,40 @@ def create_router(ctx: WebUIContext) -> APIRouter:
 
     @router.get("/api/servers/{server_id}")
     async def api_get_server(request: Request, server_id: str):
-        """Get configuration for a specific server."""
+        """Get configuration for a specific server (secrets masked)."""
         ctx.require_guild_admin(request, server_id)
         data = ctx.get_full_config()
         server_config = data.get("servers", {}).get(server_id)
         if server_config is None:
             raise HTTPException(status_code=404, detail="Serveur non trouvé")
-        return JSONResponse({"server_id": server_id, "config": server_config})
+        return JSONResponse({"server_id": server_id, "config": mask_server_config(server_config)})
 
     @router.put("/api/servers/{server_id}/modules/{module_name}")
     async def api_update_module(
         request: Request, server_id: str, module_name: str, body: ConfigUpdate
     ):
-        """Update a specific module's config for a server."""
-        ctx.require_guild_admin(request, server_id)
-        data = ctx.get_full_config()
+        """Update a specific module's config for a server.
 
-        if server_id not in data.get("servers", {}):
-            data.setdefault("servers", {})[server_id] = {}
+        Secret fields submitted as the untouched mask placeholder keep their
+        current on-disk value.
+        """
+        session = ctx.require_guild_admin(request, server_id)
+        from src.webui import schemas
 
-        data["servers"][server_id][module_name] = body.config
-        ctx.save_config(data)
-        logger.info(f"Updated {module_name} config for server {server_id}")
+        schema = schemas.MODULE_SCHEMAS.get(module_name)
+
+        def mutator(data: dict) -> None:
+            server = data.setdefault("servers", {}).setdefault(server_id, {})
+            server[module_name] = restore_section(body.config, server.get(module_name), schema)
+
+        ctx.mutate_config(mutator)
+        logger.info(
+            "Updated %s config for server %s (by %s/%s)",
+            module_name,
+            server_id,
+            session.username,
+            session.user_id,
+        )
         reload_result = _try_reload_extension_for_module(ctx, module_name)
         return JSONResponse({"status": "ok", "reload": reload_result})
 
@@ -319,21 +332,24 @@ def create_router(ctx: WebUIContext) -> APIRouter:
         request: Request, server_id: str, module_name: str, body: ModuleToggle
     ):
         """Enable or disable a module for a server."""
-        ctx.require_guild_admin(request, server_id)
-        data = ctx.get_full_config()
+        session = ctx.require_guild_admin(request, server_id)
 
-        if server_id not in data.get("servers", {}):
-            data.setdefault("servers", {})[server_id] = {}
+        def mutator(data: dict) -> None:
+            server = data.setdefault("servers", {}).setdefault(server_id, {})
+            # Hand-edited configs may hold a non-dict value here; replace it
+            # rather than crashing on the item assignment below.
+            if not isinstance(server.get(module_name), dict):
+                server[module_name] = {}
+            server[module_name]["enabled"] = body.enabled
 
-        # Hand-edited configs may hold a non-dict value here; replace it
-        # rather than crashing on the item assignment below.
-        if not isinstance(data["servers"][server_id].get(module_name), dict):
-            data["servers"][server_id][module_name] = {}
-
-        data["servers"][server_id][module_name]["enabled"] = body.enabled
-        ctx.save_config(data)
+        ctx.mutate_config(mutator)
         logger.info(
-            f"{'Enabled' if body.enabled else 'Disabled'} {module_name} for server {server_id}"
+            "%s %s for server %s (by %s/%s)",
+            "Enabled" if body.enabled else "Disabled",
+            module_name,
+            server_id,
+            session.username,
+            session.user_id,
         )
         reload_result = _try_reload_extension_for_module(ctx, module_name)
         return JSONResponse({"status": "ok", "enabled": body.enabled, "reload": reload_result})

--- a/src/webui/secrets.py
+++ b/src/webui/secrets.py
@@ -1,0 +1,103 @@
+"""Masking of secret config fields in API responses.
+
+Fields declared with ``secret=True`` in a Pydantic schema (see
+:mod:`src.webui.schemas`) are replaced by :data:`SECRET_PLACEHOLDER` before a
+config dict leaves the API. The SPA round-trips form values verbatim, so on
+save the placeholder comes back and :func:`restore_section` swaps the real
+value back in — secrets are effectively write-only from the dashboard.
+
+Schema dicts are read lazily from :mod:`src.webui.schemas` (PEP 562
+attributes) so masking always reflects every module registered at call time.
+"""
+
+from typing import Any
+
+SECRET_PLACEHOLDER = "••••••••"
+
+
+def secret_field_names(schema: dict[str, Any] | None) -> set[str]:
+    """Field names flagged ``secret`` in a module/section schema dict."""
+    if not schema:
+        return set()
+    fields = schema.get("fields") or {}
+    return {name for name, meta in fields.items() if isinstance(meta, dict) and meta.get("secret")}
+
+
+def mask_section(data: Any, schema: dict[str, Any] | None) -> Any:
+    """Return a copy of *data* with non-empty secret fields replaced by the placeholder."""
+    if not isinstance(data, dict):
+        return data
+    secret_names = secret_field_names(schema)
+    if not secret_names:
+        return dict(data)
+    masked = dict(data)
+    for name in secret_names:
+        value = masked.get(name)
+        if isinstance(value, str) and value:
+            masked[name] = SECRET_PLACEHOLDER
+    return masked
+
+
+def restore_section(
+    incoming: dict[str, Any], current: Any, schema: dict[str, Any] | None
+) -> dict[str, Any]:
+    """Return *incoming* with placeholder secrets replaced by their *current* values.
+
+    A secret field whose submitted value is the untouched placeholder means
+    "keep the existing secret"; an empty/missing field still clears it.
+    """
+    restored = dict(incoming)
+    current_dict = current if isinstance(current, dict) else {}
+    for name in secret_field_names(schema):
+        if restored.get(name) == SECRET_PLACEHOLDER:
+            restored[name] = current_dict.get(name, "")
+    return restored
+
+
+def mask_full_config(data: dict[str, Any]) -> dict[str, Any]:
+    """Mask every secret in a full ``{"config": ..., "servers": ...}`` dict.
+
+    Global sections are masked per ``GLOBAL_CONFIG_SCHEMAS``; per-guild module
+    configs per ``MODULE_SCHEMAS``. Unknown sections/modules pass through
+    unchanged (their fields are not known to be secret).
+    """
+    from src.webui import schemas
+
+    section_schemas = schemas.GLOBAL_CONFIG_SCHEMAS
+    module_schemas = schemas.MODULE_SCHEMAS
+
+    masked: dict[str, Any] = dict(data)
+
+    global_config = data.get("config")
+    if isinstance(global_config, dict):
+        masked["config"] = {
+            section: mask_section(section_data, section_schemas.get(section))
+            for section, section_data in global_config.items()
+        }
+
+    servers = data.get("servers")
+    if isinstance(servers, dict):
+        masked["servers"] = {
+            server_id: {
+                module: mask_section(module_data, module_schemas.get(module))
+                for module, module_data in server_config.items()
+            }
+            if isinstance(server_config, dict)
+            else server_config
+            for server_id, server_config in servers.items()
+        }
+
+    return masked
+
+
+def mask_server_config(server_config: Any) -> Any:
+    """Mask secret module fields in a single per-guild config dict."""
+    if not isinstance(server_config, dict):
+        return server_config
+    from src.webui import schemas
+
+    module_schemas = schemas.MODULE_SCHEMAS
+    return {
+        module: mask_section(module_data, module_schemas.get(module))
+        for module, module_data in server_config.items()
+    }

--- a/tests/test_core_config_mutate.py
+++ b/tests/test_core_config_mutate.py
@@ -1,0 +1,114 @@
+"""Tests for ConfigStore.mutate (atomic read-modify-write) and its WebUI wrapper."""
+
+import json
+
+import pytest
+from fastapi import HTTPException
+
+from src.core import config as core_config
+from src.core.config import config_store
+from src.core.errors import ConfigError
+from src.webui.auth import DiscordOAuth
+from src.webui.context import WebUIContext
+
+
+@pytest.fixture
+def config_file(tmp_path, monkeypatch):
+    path = tmp_path / "config.json"
+    path.write_text(
+        json.dumps({"config": {"discord": {"devGuildId": "1"}}, "servers": {}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(core_config, "CONFIG_PATH", str(path))
+    # Reset the singleton cache so tests don't see each other's data.
+    config_store._data = None
+    yield path
+    config_store._data = None
+
+
+def read_config(path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_mutate_applies_and_persists(config_file):
+    def mutator(data):
+        data["servers"]["42"] = {"moduleXp": {"enabled": True}}
+
+    result = config_store.mutate(mutator)
+    assert result["servers"]["42"]["moduleXp"]["enabled"] is True
+    on_disk = read_config(config_file)
+    assert on_disk["servers"]["42"]["moduleXp"]["enabled"] is True
+    # The store cache reflects the mutation too.
+    assert config_store.get()["servers"]["42"]["moduleXp"]["enabled"] is True
+
+
+def test_sequential_mutations_do_not_lose_updates(config_file):
+    config_store.mutate(lambda d: d["servers"].update({"1": {"a": 1}}))
+    config_store.mutate(lambda d: d["servers"].update({"2": {"b": 2}}))
+    on_disk = read_config(config_file)
+    assert on_disk["servers"] == {"1": {"a": 1}, "2": {"b": 2}}
+
+
+def test_mutate_notifies_subscribers(config_file):
+    seen = []
+    unsubscribe = config_store.subscribe(seen.append)
+    try:
+        config_store.mutate(lambda d: d["servers"].update({"7": {}}))
+    finally:
+        unsubscribe()
+    assert len(seen) == 1
+    assert "7" in seen[0]["servers"]
+
+
+def test_mutate_refuses_missing_or_empty_config(tmp_path, monkeypatch):
+    monkeypatch.setattr(core_config, "CONFIG_PATH", str(tmp_path / "absent.json"))
+    config_store._data = None
+    called = []
+    with pytest.raises(ConfigError):
+        config_store.mutate(called.append)
+    assert called == []
+
+
+def test_mutate_does_not_write_when_mutator_raises(config_file):
+    before = read_config(config_file)
+
+    def mutator(data):
+        data["servers"]["evil"] = {}
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError):
+        config_store.mutate(mutator)
+    assert read_config(config_file) == before
+
+
+@pytest.fixture
+def ctx():
+    oauth = DiscordOAuth(client_id="", client_secret="", redirect_uri="")
+    return WebUIContext(bot=None, bot_loop=None, oauth=oauth)
+
+
+def test_mutate_config_maps_config_error_to_503(ctx, monkeypatch):
+    def boom(_mutator):
+        raise ConfigError("unreadable")
+
+    monkeypatch.setattr(config_store, "mutate", boom)
+    with pytest.raises(HTTPException) as exc:
+        ctx.mutate_config(lambda d: None)
+    assert exc.value.status_code == 503
+    assert "refusée" in exc.value.detail
+
+
+def test_mutate_config_surfaces_permission_error(ctx, monkeypatch):
+    def boom(_mutator):
+        raise PermissionError(13, "Permission denied", "config/.config-x.json.tmp")
+
+    monkeypatch.setattr(config_store, "mutate", boom)
+    with pytest.raises(HTTPException) as exc:
+        ctx.mutate_config(lambda d: None)
+    assert exc.value.status_code == 500
+    assert "chown -R 1000:1000" in exc.value.detail
+
+
+def test_mutate_config_passes_through_result(ctx, monkeypatch, config_file):
+    result = ctx.mutate_config(lambda d: d["servers"].update({"9": {}}))
+    assert "9" in result["servers"]

--- a/tests/test_webui_ratelimit.py
+++ b/tests/test_webui_ratelimit.py
@@ -1,0 +1,88 @@
+"""Tests for the auth-endpoint rate limiter."""
+
+from src.webui import ratelimit
+from src.webui.ratelimit import RateLimiter, client_ip
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.now = 1000.0
+
+    def monotonic(self) -> float:
+        return self.now
+
+
+def make_limiter(monkeypatch, max_requests=3, window=60.0):
+    clock = FakeClock()
+    monkeypatch.setattr(ratelimit, "time", clock)
+    return RateLimiter(max_requests, window), clock
+
+
+def test_allows_up_to_limit_then_blocks(monkeypatch):
+    limiter, _ = make_limiter(monkeypatch)
+    assert limiter.check("ip") == 0.0
+    assert limiter.check("ip") == 0.0
+    assert limiter.check("ip") == 0.0
+    assert limiter.check("ip") > 0.0
+
+
+def test_keys_are_independent(monkeypatch):
+    limiter, _ = make_limiter(monkeypatch, max_requests=1)
+    assert limiter.check("a") == 0.0
+    assert limiter.check("a") > 0.0
+    assert limiter.check("b") == 0.0
+
+
+def test_window_expiry_frees_budget(monkeypatch):
+    limiter, clock = make_limiter(monkeypatch, max_requests=2, window=60.0)
+    limiter.check("ip")
+    limiter.check("ip")
+    assert limiter.check("ip") > 0.0
+    clock.now += 61.0
+    assert limiter.check("ip") == 0.0
+
+
+def test_refused_attempts_do_not_extend_the_block(monkeypatch):
+    limiter, clock = make_limiter(monkeypatch, max_requests=1, window=60.0)
+    limiter.check("ip")
+    for _ in range(5):
+        assert limiter.check("ip") > 0.0
+    clock.now += 60.5
+    assert limiter.check("ip") == 0.0
+
+
+def test_retry_after_reflects_window_remaining(monkeypatch):
+    limiter, clock = make_limiter(monkeypatch, max_requests=1, window=60.0)
+    limiter.check("ip")
+    clock.now += 20.0
+    retry_after = limiter.check("ip")
+    assert 39.0 <= retry_after <= 41.0
+
+
+def test_idle_keys_are_pruned(monkeypatch):
+    limiter, clock = make_limiter(monkeypatch, max_requests=2, window=60.0)
+    limiter.check("old")
+    clock.now += 120.0
+    limiter.check("new")
+    assert "old" not in limiter._hits
+
+
+class FakeClient:
+    host = "10.0.0.5"
+
+
+class FakeRequest:
+    def __init__(self, headers=None, client=FakeClient()):
+        self.headers = headers or {}
+        self.client = client
+
+
+def test_client_ip_prefers_forwarded_for():
+    request = FakeRequest(headers={"x-forwarded-for": "203.0.113.7, 10.0.0.1"})
+    assert client_ip(request) == "203.0.113.7"
+
+
+def test_client_ip_falls_back_to_socket_peer():
+    assert client_ip(FakeRequest()) == "10.0.0.5"
+    assert client_ip(FakeRequest(headers={"x-forwarded-for": "  "})) == "10.0.0.5"
+    assert client_ip(FakeRequest(client=None)) == "unknown"

--- a/tests/test_webui_secrets.py
+++ b/tests/test_webui_secrets.py
@@ -18,6 +18,13 @@ FAKE_SCHEMA = {
     },
 }
 
+# Obviously fake fixture values, hoisted into constants so detect-secrets'
+# keyword detector doesn't match `"apiKey": "<literal>"` lines all over the file.
+FAKE_SECRET = "hunter2"  # pragma: allowlist secret
+NEW_SECRET = "new-secret"  # pragma: allowlist secret
+OLD_SECRET = "old-secret"  # pragma: allowlist secret
+FAKE_TOKEN = "tok-123"  # pragma: allowlist secret
+
 
 @register_module("moduleSecretMaskTest")
 class _SecretMaskTestConfig(SchemaBase):
@@ -35,12 +42,12 @@ def test_secret_field_names_reads_schema_meta():
 
 
 def test_mask_section_masks_only_set_secrets():
-    data = {"apiKey": "hunter2", "channel": "123"}
+    data = {"apiKey": FAKE_SECRET, "channel": "123"}
     masked = mask_section(data, FAKE_SCHEMA)
     assert masked["apiKey"] == SECRET_PLACEHOLDER
     assert masked["channel"] == "123"
     # original untouched
-    assert data["apiKey"] == "hunter2"
+    assert data["apiKey"] == FAKE_SECRET
 
 
 def test_mask_section_leaves_empty_and_missing_secrets():
@@ -49,7 +56,7 @@ def test_mask_section_leaves_empty_and_missing_secrets():
 
 
 def test_mask_section_without_schema_is_passthrough_copy():
-    data = {"apiKey": "hunter2"}
+    data = {"apiKey": FAKE_SECRET}
     masked = mask_section(data, None)
     assert masked == data
     assert masked is not data
@@ -62,22 +69,22 @@ def test_mask_section_non_dict_passthrough():
 
 def test_restore_section_swaps_placeholder_for_current_value():
     incoming = {"apiKey": SECRET_PLACEHOLDER, "channel": "456"}
-    current = {"apiKey": "hunter2", "channel": "123"}
+    current = {"apiKey": FAKE_SECRET, "channel": "123"}
     restored = restore_section(incoming, current, FAKE_SCHEMA)
-    assert restored["apiKey"] == "hunter2"
+    assert restored["apiKey"] == FAKE_SECRET
     assert restored["channel"] == "456"
 
 
 def test_restore_section_keeps_new_secret_value():
-    restored = restore_section({"apiKey": "new-secret"}, {"apiKey": "old"}, FAKE_SCHEMA)
-    assert restored["apiKey"] == "new-secret"
+    restored = restore_section({"apiKey": NEW_SECRET}, {"apiKey": OLD_SECRET}, FAKE_SCHEMA)
+    assert restored["apiKey"] == NEW_SECRET
 
 
 def test_restore_section_clearing_still_works():
     # Empty/missing means "clear" — only the untouched placeholder is restored.
-    restored = restore_section({"apiKey": ""}, {"apiKey": "old"}, FAKE_SCHEMA)
+    restored = restore_section({"apiKey": ""}, {"apiKey": OLD_SECRET}, FAKE_SCHEMA)
     assert restored["apiKey"] == ""
-    restored = restore_section({"channel": "1"}, {"apiKey": "old"}, FAKE_SCHEMA)
+    restored = restore_section({"channel": "1"}, {"apiKey": OLD_SECRET}, FAKE_SCHEMA)
     assert "apiKey" not in restored
 
 
@@ -87,7 +94,7 @@ def test_restore_section_placeholder_without_current_becomes_empty():
 
 
 def test_mask_round_trip_is_identity_for_unchanged_secrets():
-    current = {"apiKey": "hunter2", "channel": "123"}
+    current = {"apiKey": FAKE_SECRET, "channel": "123"}
     masked = mask_section(current, FAKE_SCHEMA)
     restored = restore_section(masked, current, FAKE_SCHEMA)
     assert restored == current
@@ -96,12 +103,12 @@ def test_mask_round_trip_is_identity_for_unchanged_secrets():
 def test_mask_full_config_masks_global_sections_and_modules():
     data = {
         "config": {
-            "discord": {"botToken": "tok-123", "devGuildId": "42"},
+            "discord": {"botToken": FAKE_TOKEN, "devGuildId": "42"},
             "extensions": {"extensions.xp": True},
         },
         "servers": {
             "1": {
-                "moduleSecretMaskTest": {"enabled": True, "password": "s3cret"},
+                "moduleSecretMaskTest": {"enabled": True, "password": FAKE_SECRET},
                 "discord2name": {"99": "Alice"},
             },
         },
@@ -118,11 +125,11 @@ def test_mask_full_config_masks_global_sections_and_modules():
     assert module["enabled"] is True
     assert masked["servers"]["1"]["discord2name"] == {"99": "Alice"}
     # source dict untouched
-    assert data["config"]["discord"]["botToken"] == "tok-123"
+    assert data["config"]["discord"]["botToken"] == FAKE_TOKEN
 
 
 def test_mask_server_config_masks_registered_module():
-    server_config = {"moduleSecretMaskTest": {"password": "s3cret", "channelId": "1"}}
+    server_config = {"moduleSecretMaskTest": {"password": FAKE_SECRET, "channelId": "1"}}
     masked = mask_server_config(server_config)
     assert masked["moduleSecretMaskTest"]["password"] == SECRET_PLACEHOLDER
     assert masked["moduleSecretMaskTest"]["channelId"] == "1"

--- a/tests/test_webui_secrets.py
+++ b/tests/test_webui_secrets.py
@@ -1,0 +1,128 @@
+"""Tests for secret masking/restoring in Web UI config endpoints."""
+
+from src.webui.schemas import SchemaBase, register_module, secret_field, ui
+from src.webui.secrets import (
+    SECRET_PLACEHOLDER,
+    mask_full_config,
+    mask_section,
+    mask_server_config,
+    restore_section,
+    secret_field_names,
+)
+
+FAKE_SCHEMA = {
+    "label": "Test",
+    "fields": {
+        "apiKey": {"label": "Clé", "type": "secret", "secret": True},
+        "channel": {"label": "Salon", "type": "channel"},
+    },
+}
+
+
+@register_module("moduleSecretMaskTest")
+class _SecretMaskTestConfig(SchemaBase):
+    __label__ = "Module de test (masquage)"
+
+    enabled: bool = ui("Activé", "boolean", default=False)
+    password: str | None = secret_field("Mot de passe")
+    channelId: str | None = ui("Salon", "channel")
+
+
+def test_secret_field_names_reads_schema_meta():
+    assert secret_field_names(FAKE_SCHEMA) == {"apiKey"}
+    assert secret_field_names(None) == set()
+    assert secret_field_names({"fields": {}}) == set()
+
+
+def test_mask_section_masks_only_set_secrets():
+    data = {"apiKey": "hunter2", "channel": "123"}
+    masked = mask_section(data, FAKE_SCHEMA)
+    assert masked["apiKey"] == SECRET_PLACEHOLDER
+    assert masked["channel"] == "123"
+    # original untouched
+    assert data["apiKey"] == "hunter2"
+
+
+def test_mask_section_leaves_empty_and_missing_secrets():
+    assert mask_section({"apiKey": "", "channel": "1"}, FAKE_SCHEMA)["apiKey"] == ""
+    assert "apiKey" not in mask_section({"channel": "1"}, FAKE_SCHEMA)
+
+
+def test_mask_section_without_schema_is_passthrough_copy():
+    data = {"apiKey": "hunter2"}
+    masked = mask_section(data, None)
+    assert masked == data
+    assert masked is not data
+
+
+def test_mask_section_non_dict_passthrough():
+    assert mask_section("raw", FAKE_SCHEMA) == "raw"
+    assert mask_section(None, FAKE_SCHEMA) is None
+
+
+def test_restore_section_swaps_placeholder_for_current_value():
+    incoming = {"apiKey": SECRET_PLACEHOLDER, "channel": "456"}
+    current = {"apiKey": "hunter2", "channel": "123"}
+    restored = restore_section(incoming, current, FAKE_SCHEMA)
+    assert restored["apiKey"] == "hunter2"
+    assert restored["channel"] == "456"
+
+
+def test_restore_section_keeps_new_secret_value():
+    restored = restore_section({"apiKey": "new-secret"}, {"apiKey": "old"}, FAKE_SCHEMA)
+    assert restored["apiKey"] == "new-secret"
+
+
+def test_restore_section_clearing_still_works():
+    # Empty/missing means "clear" — only the untouched placeholder is restored.
+    restored = restore_section({"apiKey": ""}, {"apiKey": "old"}, FAKE_SCHEMA)
+    assert restored["apiKey"] == ""
+    restored = restore_section({"channel": "1"}, {"apiKey": "old"}, FAKE_SCHEMA)
+    assert "apiKey" not in restored
+
+
+def test_restore_section_placeholder_without_current_becomes_empty():
+    restored = restore_section({"apiKey": SECRET_PLACEHOLDER}, None, FAKE_SCHEMA)
+    assert restored["apiKey"] == ""
+
+
+def test_mask_round_trip_is_identity_for_unchanged_secrets():
+    current = {"apiKey": "hunter2", "channel": "123"}
+    masked = mask_section(current, FAKE_SCHEMA)
+    restored = restore_section(masked, current, FAKE_SCHEMA)
+    assert restored == current
+
+
+def test_mask_full_config_masks_global_sections_and_modules():
+    data = {
+        "config": {
+            "discord": {"botToken": "tok-123", "devGuildId": "42"},
+            "extensions": {"extensions.xp": True},
+        },
+        "servers": {
+            "1": {
+                "moduleSecretMaskTest": {"enabled": True, "password": "s3cret"},
+                "discord2name": {"99": "Alice"},
+            },
+        },
+    }
+    masked = mask_full_config(data)
+    # discord.botToken is secret in the real GLOBAL_CONFIG_SCHEMAS
+    assert masked["config"]["discord"]["botToken"] == SECRET_PLACEHOLDER
+    assert masked["config"]["discord"]["devGuildId"] == "42"
+    # schema-less sections pass through
+    assert masked["config"]["extensions"] == {"extensions.xp": True}
+    # registered module secret is masked, other fields untouched
+    module = masked["servers"]["1"]["moduleSecretMaskTest"]
+    assert module["password"] == SECRET_PLACEHOLDER
+    assert module["enabled"] is True
+    assert masked["servers"]["1"]["discord2name"] == {"99": "Alice"}
+    # source dict untouched
+    assert data["config"]["discord"]["botToken"] == "tok-123"
+
+
+def test_mask_server_config_masks_registered_module():
+    server_config = {"moduleSecretMaskTest": {"password": "s3cret", "channelId": "1"}}
+    masked = mask_server_config(server_config)
+    assert masked["moduleSecretMaskTest"]["password"] == SECRET_PLACEHOLDER
+    assert masked["moduleSecretMaskTest"]["channelId"] == "1"


### PR DESCRIPTION
## Summary

Implements the Web UI hardening items from the audit behind #67: secrets become write-only from the dashboard, the OAuth endpoints get rate-limited, and the config save race is closed.

### 1. Secret masking (`src/webui/secrets.py`)

Every schema field declared `secret=True` is masked to a fixed placeholder (`••••••••`) in API responses:

- `/api/config` and `/api/global-config` (global sections, e.g. bot token, client secrets, API keys)
- `/api/servers` and `/api/servers/{id}` (per-guild module secrets, e.g. minecraft RCON/SFTP and satisfactory passwords)

The save paths (`PUT /api/global-config/{section}`, `PUT /api/servers/{id}/modules/{module}`) call `restore_section()`: a secret submitted as the untouched placeholder keeps its current on-disk value. The SPA needs no changes — it round-trips form values verbatim, and both the schema-form and raw-JSON editors merge over the masked section. Clearing a secret (emptying the field) still works.

### 2. Auth rate limiting (`src/webui/ratelimit.py`)

`/auth/login` and `/auth/callback` share a sliding-window budget of 10 requests/60 s per client IP (leftmost `X-Forwarded-For`, falling back to the socket peer — the dashboard binds loopback behind a reverse proxy). Beyond the budget: `429` with a `Retry-After` header. Refused attempts don't extend the block.

### 3. Atomic config mutations

- New `ConfigStore.mutate(mutator)` does read-modify-write under the existing write lock, and refuses to write when the config file is unreadable/empty (raises `ConfigError`) instead of clobbering it. A mutator exception aborts without writing.
- New `WebUIContext.mutate_config()` wraps it with the dashboard error handling (503 on unreadable config, 500 with the chown hint on `PermissionError`).
- All webui mutation routes converted from the racy `get_full_config()` + `save_config()` sequence: global-config PUT, cleanup-config, per-guild module update/toggle, extension toggle. Two concurrent dashboard saves can no longer silently drop one of the edits.

### 4. Audit trail

Config mutation log lines now include the acting dashboard user (`username/user_id` from the session).

### Tests

28 new tests across `test_webui_secrets.py` (mask/restore round-trips, clearing, full-config masking against the real schema registry), `test_webui_ratelimit.py` (window behavior, key isolation, pruning, X-Forwarded-For parsing), and `test_core_config_mutate.py` (atomicity, refusal on unreadable file, no-write-on-mutator-failure, error mapping). Full suite: **101 passed**; ruff and `mypy src` clean.

CLAUDE.md documents the new rules (mutate_config for writes, mask/restore for any endpoint touching config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)